### PR TITLE
BZ1201853: Huge amount ClassNotFoundException WARNs on Project build

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-services-backend/pom.xml
@@ -215,25 +215,4 @@
 
   </dependencies>
 
-  <build>
-
-    <plugins>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>${basedir}</directory>
-              <includes>
-                <include>.niogit/**</include>
-                <include>repository/**</include>
-              </includes>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
-    </plugins>
-
-  </build>
-
 </project>

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/PackageNameWhiteList.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/PackageNameWhiteList.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.backend.builder;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.guvnor.common.services.project.model.Project;
+import org.kie.workbench.common.services.backend.file.AntPathMatcher;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Files;
+
+/**
+ * Represents a "white list" of permitted package names for use with authoring
+ */
+public class PackageNameWhiteList {
+
+    private static final AntPathMatcher ANT_PATH_MATCHER = new AntPathMatcher();
+
+    private IOService ioService;
+
+    @Inject
+    public PackageNameWhiteList( final @Named("ioStrategy") IOService ioService ) {
+        this.ioService = ioService;
+    }
+
+    /**
+     * Filter the provided Package names by the Project's white list
+     * @param project Project for which to filter Package names
+     * @param packageNames All Package names in the Project
+     * @return A filtered collection of Package names
+     */
+    public Set<String> filterPackageNames( final Project project,
+                                           final Collection<String> packageNames ) {
+        final Set<String> packageNamesWhiteList = new HashSet<String>();
+        if ( packageNames == null ) {
+            return packageNamesWhiteList;
+        }
+        packageNamesWhiteList.addAll( packageNames );
+        if ( !( project instanceof KieProject ) ) {
+            return packageNamesWhiteList;
+        }
+
+        final org.uberfire.java.nio.file.Path packageNamesWhiteListPath = Paths.convert( ( (KieProject) project ).getPackageNamesWhiteList() );
+
+        if ( Files.exists( packageNamesWhiteListPath ) ) {
+            final String content = ioService.readAllString( packageNamesWhiteListPath );
+            if ( !( content == null || content.trim().isEmpty() ) ) {
+
+                //If a White List is defined build set of acceptable Package Names from it
+                packageNamesWhiteList.clear();
+                final String[] patterns = content.split( System.getProperty( "line.separator" ) );
+
+                //Convert to Paths as we're delegating to an Ant-style pattern matcher.
+                //Convert once outside of the nested loops for performance reasons.
+                for ( int i = 0; i < patterns.length; i++ ) {
+                    patterns[ i ] = patterns[ i ].replaceAll( "\\.",
+                                                              AntPathMatcher.DEFAULT_PATH_SEPARATOR );
+                }
+                final HashMap<String, String> packageNamePaths = new HashMap<String, String>();
+                for ( String packageName : packageNames ) {
+                    packageNamePaths.put( packageName,
+                                          packageName.replaceAll( "\\.",
+                                                                  AntPathMatcher.DEFAULT_PATH_SEPARATOR ) );
+                }
+
+                //Add Package Names matching the White List to the available packages
+                for ( String pattern : patterns ) {
+                    for ( Map.Entry<String, String> pnp : packageNamePaths.entrySet() ) {
+                        if ( ANT_PATH_MATCHER.match( pattern,
+                                                     pnp.getValue() ) ) {
+                            packageNamesWhiteList.add( pnp.getKey() );
+                        }
+                    }
+                }
+            }
+        }
+
+        return packageNamesWhiteList;
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuildServiceImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuildServiceImplTest.java
@@ -26,12 +26,13 @@ import org.drools.core.rule.TypeMetaInfo;
 import org.guvnor.common.services.project.builder.model.BuildMessage;
 import org.guvnor.common.services.project.builder.model.BuildResults;
 import org.guvnor.common.services.project.builder.service.BuildValidationHelper;
-import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.model.Project;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.scanner.KieModuleMetaData;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.kie.workbench.common.services.shared.project.ProjectImportsService;
+import org.uberfire.backend.server.util.Paths;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
@@ -39,7 +40,6 @@ import static org.junit.Assert.*;
 
 public class BuildServiceImplTest
         extends BuilderTestBase {
-
 
     @Before
     public void setUp() throws Exception {
@@ -57,12 +57,14 @@ public class BuildServiceImplTest
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
         org.uberfire.java.nio.file.Path path = p.getPath( url.toURI() );
 
-        final Builder builder = new Builder( path,
-                                             new GAV(),
+        final Project project = projectService.resolveProject( Paths.convert( path ) );
+
+        final Builder builder = new Builder( project,
                                              ioService,
                                              projectService,
                                              importsService,
-                                             new ArrayList<BuildValidationHelper>() );
+                                             new ArrayList<BuildValidationHelper>(),
+                                             new PackageNameWhiteList( ioService ) );
 
         final BuildResults results = builder.build();
 
@@ -79,12 +81,14 @@ public class BuildServiceImplTest
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
         org.uberfire.java.nio.file.Path path = p.getPath( url.toURI() );
 
-        final Builder builder = new Builder( path,
-                                             new GAV(),
+        final Project project = projectService.resolveProject( Paths.convert( path ) );
+
+        final Builder builder = new Builder( project,
                                              ioService,
                                              projectService,
                                              importsService,
-                                             new ArrayList<BuildValidationHelper>() );
+                                             new ArrayList<BuildValidationHelper>(),
+                                             new PackageNameWhiteList( ioService ) );
 
         final BuildResults results = builder.build();
 
@@ -108,12 +112,14 @@ public class BuildServiceImplTest
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
         org.uberfire.java.nio.file.Path path = p.getPath( url.toURI() );
 
-        final Builder builder = new Builder( path,
-                                             new GAV(),
+        final Project project = projectService.resolveProject( Paths.convert( path ) );
+
+        final Builder builder = new Builder( project,
                                              ioService,
                                              projectService,
                                              importsService,
-                                             new ArrayList<BuildValidationHelper>() );
+                                             new ArrayList<BuildValidationHelper>(),
+                                             new PackageNameWhiteList( ioService ) );
 
         final BuildResults results = builder.build();
 
@@ -137,12 +143,14 @@ public class BuildServiceImplTest
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
         org.uberfire.java.nio.file.Path path = p.getPath( url.toURI() );
 
-        final Builder builder = new Builder( path,
-                                             new GAV(),
+        final Project project = projectService.resolveProject( Paths.convert( path ) );
+
+        final Builder builder = new Builder( project,
                                              ioService,
                                              projectService,
                                              importsService,
-                                             new ArrayList<BuildValidationHelper>() );
+                                             new ArrayList<BuildValidationHelper>(),
+                                             new PackageNameWhiteList( ioService ) );
 
         final BuildResults results = builder.build();
 
@@ -194,12 +202,14 @@ public class BuildServiceImplTest
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
         org.uberfire.java.nio.file.Path path = p.getPath( url.toURI() );
 
-        final Builder builder = new Builder( path,
-                                             new GAV(),
+        final Project project = projectService.resolveProject( Paths.convert( path ) );
+
+        final Builder builder = new Builder( project,
                                              ioService,
                                              projectService,
                                              importsService,
-                                             new ArrayList<BuildValidationHelper>() );
+                                             new ArrayList<BuildValidationHelper>(),
+                                             new PackageNameWhiteList( ioService ) );
 
         final BuildResults results = builder.build();
 

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuilderTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuilderTest.java
@@ -21,11 +21,12 @@ import java.net.URL;
 import java.util.ArrayList;
 
 import org.guvnor.common.services.project.builder.service.BuildValidationHelper;
-import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.model.Project;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.kie.workbench.common.services.shared.project.ProjectImportsService;
+import org.uberfire.backend.server.util.Paths;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
@@ -42,51 +43,55 @@ public class BuilderTest
 
     @Test
     public void testBuilderSimpleKProject() throws Exception {
-        IOService ioService = getReference(IOService.class);
-        KieProjectService projectService = getReference(KieProjectService.class);
-        ProjectImportsService importsService = getReference(ProjectImportsService.class);
+        IOService ioService = getReference( IOService.class );
+        KieProjectService projectService = getReference( KieProjectService.class );
+        ProjectImportsService importsService = getReference( ProjectImportsService.class );
 
-        URL url = this.getClass().getResource("/GuvnorM2RepoDependencyExample1");
+        URL url = this.getClass().getResource( "/GuvnorM2RepoDependencyExample1" );
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
-        org.uberfire.java.nio.file.Path path = p.getPath(url.toURI());
+        org.uberfire.java.nio.file.Path path = p.getPath( url.toURI() );
 
-        final Builder builder = new Builder(path,
-                                            new GAV(),
-                                            ioService,
-                                            projectService,
-                                            importsService,
-                                            new ArrayList<BuildValidationHelper>());
+        final Project project = projectService.resolveProject( Paths.convert( path ) );
 
-        assertNotNull(builder.getKieContainer());
+        final Builder builder = new Builder( project,
+                                             ioService,
+                                             projectService,
+                                             importsService,
+                                             new ArrayList<BuildValidationHelper>(),
+                                             new PackageNameWhiteList( ioService ) );
+
+        assertNotNull( builder.getKieContainer() );
     }
 
     @Test
     public void testBuilderFixForBrokenKProject() throws Exception {
 
-        IOService ioService = getReference(IOService.class);
-        KieProjectService projectService = getReference(KieProjectService.class);
-        ProjectImportsService importsService = getReference(ProjectImportsService.class);
+        IOService ioService = getReference( IOService.class );
+        KieProjectService projectService = getReference( KieProjectService.class );
+        ProjectImportsService importsService = getReference( ProjectImportsService.class );
 
         SimpleFileSystemProvider provider = new SimpleFileSystemProvider();
-        org.uberfire.java.nio.file.Path path = provider.getPath(this.getClass().getResource("/BuilderExampleBrokenSyntax").toURI());
+        org.uberfire.java.nio.file.Path path = provider.getPath( this.getClass().getResource( "/BuilderExampleBrokenSyntax" ).toURI() );
 
-        final Builder builder = new Builder(path,
-                                            new GAV(),
-                                            ioService,
-                                            projectService,
-                                            importsService,
-                                            new ArrayList<BuildValidationHelper>());
+        final Project project = projectService.resolveProject( Paths.convert( path ) );
 
-        assertNull(builder.getKieContainer());
+        final Builder builder = new Builder( project,
+                                             ioService,
+                                             projectService,
+                                             importsService,
+                                             new ArrayList<BuildValidationHelper>(),
+                                             new PackageNameWhiteList( ioService ) );
 
-        builder.deleteResource(provider.getPath(this.getClass().getResource(File.separatorChar + "BuilderExampleBrokenSyntax" +
-                                                                            File.separatorChar + "src" +
-                                                                            File.separatorChar + "main" +
-                                                                            File.separatorChar + "resources" +
-                                                                            File.separatorChar + "rule1.drl"
-                                                                           ).toURI()));
+        assertNull( builder.getKieContainer() );
 
-        assertNotNull(builder.getKieContainer());
+        builder.deleteResource( provider.getPath( this.getClass().getResource( File.separatorChar + "BuilderExampleBrokenSyntax" +
+                                                                                       File.separatorChar + "src" +
+                                                                                       File.separatorChar + "main" +
+                                                                                       File.separatorChar + "resources" +
+                                                                                       File.separatorChar + "rule1.drl"
+                                                                             ).toURI() ) );
+
+        assertNotNull( builder.getKieContainer() );
     }
 
 }

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/project/ProjectServiceImplNewProjectTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/project/ProjectServiceImplNewProjectTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.backend.project;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.enterprise.event.Event;
+
+import org.guvnor.common.services.project.backend.server.ProjectConfigurationContentHandler;
+import org.guvnor.common.services.project.builder.events.InvalidateDMOProjectCacheEvent;
+import org.guvnor.common.services.project.events.DeleteProjectEvent;
+import org.guvnor.common.services.project.events.NewPackageEvent;
+import org.guvnor.common.services.project.events.NewProjectEvent;
+import org.guvnor.common.services.project.events.RenameProjectEvent;
+import org.guvnor.common.services.project.model.POM;
+import org.guvnor.common.services.project.model.Package;
+import org.guvnor.common.services.project.model.Project;
+import org.guvnor.common.services.project.service.POMService;
+import org.guvnor.common.services.project.service.ProjectService;
+import org.guvnor.structure.repositories.Repository;
+import org.guvnor.structure.server.config.ConfigurationFactory;
+import org.guvnor.structure.server.config.ConfigurationService;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.services.shared.kmodule.KModuleService;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystemNotFoundException;
+import org.uberfire.java.nio.file.FileSystems;
+import org.uberfire.rpc.SessionInfo;
+
+import static junit.framework.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ProjectServiceImplNewProjectTest {
+
+    private IOService ioService;
+    private ProjectService projectService;
+
+    @Before
+    public void setup() {
+        ioService = mock( IOService.class );
+
+        final POMService pomService = mock( POMService.class );
+        final KModuleService kModuleService = mock( KModuleService.class );
+        final ProjectConfigurationContentHandler projectConfigurationContentHandler = new ProjectConfigurationContentHandler();
+        final ConfigurationService configurationService = mock( ConfigurationService.class );
+        final ConfigurationFactory configurationFactory = mock( ConfigurationFactory.class );
+        final Event<NewProjectEvent> newProjectEvent = mock( Event.class );
+        final Event<NewPackageEvent> newPackageEvent = mock( Event.class );
+        final Event<RenameProjectEvent> renameProjectEvent = mock( Event.class );
+        final Event<DeleteProjectEvent> deleteProjectEvent = mock( Event.class );
+        final Event<InvalidateDMOProjectCacheEvent> invalidateDMOCache = mock( Event.class );
+        final User identity = mock( User.class );
+        final SessionInfo sessionInfo = mock( SessionInfo.class );
+
+        final Project project = mock( Project.class );
+        final Path projectRootPath = mock( Path.class );
+        when( project.getRootPath() ).thenReturn( projectRootPath );
+        when( projectRootPath.toURI() ).thenReturn( "git://test/p0" );
+
+        when( ioService.createDirectory( any( org.uberfire.java.nio.file.Path.class ) ) ).thenAnswer( new Answer<Object>() {
+            @Override
+            public Object answer( final InvocationOnMock invocation ) throws Throwable {
+                return invocation.getArguments()[ 0 ];
+            }
+        } );
+
+        projectService = new ProjectServiceImpl( ioService,
+                                                 pomService,
+                                                 kModuleService,
+                                                 projectConfigurationContentHandler,
+                                                 configurationService,
+                                                 configurationFactory,
+                                                 newProjectEvent,
+                                                 newPackageEvent,
+                                                 renameProjectEvent,
+                                                 deleteProjectEvent,
+                                                 invalidateDMOCache,
+                                                 identity,
+                                                 sessionInfo ) {
+
+            @Override
+            //Override Package resolution as we don't have the Project Structure set-up in this test
+            public Package resolvePackage( final Path resource ) {
+                return makePackage( project,
+                                    resource );
+            }
+        };
+        assertNotNull( projectService );
+    }
+
+    @Test
+    public void testPackageNameWhiteList() throws URISyntaxException {
+        final URI fs = new URI( "git://test" );
+        try {
+            FileSystems.getFileSystem( fs );
+        } catch ( FileSystemNotFoundException e ) {
+            FileSystems.newFileSystem( fs,
+                                       new HashMap<String, Object>() );
+        }
+
+        final Map<String, String> writes = new HashMap<String, String>();
+
+        final Repository repository = mock( Repository.class );
+        final String name = "p0";
+        final POM pom = new POM();
+        final String baseURL = "/";
+
+        final Path repositoryRootPath = mock( Path.class );
+        when( repository.getRoot() ).thenReturn( repositoryRootPath );
+        when( repositoryRootPath.toURI() ).thenReturn( "git://test" );
+
+        when( ioService.write( any( org.uberfire.java.nio.file.Path.class ),
+                               anyString() ) ).thenAnswer( new Answer<Object>() {
+            @Override
+            public Object answer( final InvocationOnMock invocation ) throws Throwable {
+                if ( invocation.getArguments().length == 2 ) {
+                    final String path = ( (org.uberfire.java.nio.file.Path) invocation.getArguments()[ 0 ] ).toUri().getPath();
+                    final String content = ( (String) invocation.getArguments()[ 1 ] );
+                    writes.put( path,
+                                content );
+                }
+                return invocation.getArguments()[ 0 ];
+            }
+        } );
+
+        pom.getGav().setGroupId( "org.kie.workbench.services" );
+        pom.getGav().setArtifactId( "kie-wb-common-services-test" );
+        pom.getGav().setVersion( "1.0.0-SNAPSHOT" );
+
+        projectService.newProject( repository,
+                                   name,
+                                   pom,
+                                   baseURL );
+
+        assertTrue( writes.containsKey( "/p0/package-names-white-list" ) );
+        assertEquals( "org.kie.workbench.services.kie_wb_common_services_test.**",
+                      writes.get( "/p0/package-names-white-list" ) );
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
               <directory>${basedir}</directory>
               <includes>
                 <include>repository/**</include>
+                <include>.niogit/**</include>
               </includes>
             </fileset>
           </filesets>


### PR DESCRIPTION
@wmedvede @mswiderski 

This PR is for https://bugzilla.redhat.com/show_bug.cgi?id=1201853.

It sets the "package name white-list" to the default package created for new projects: https://github.com/droolsjbpm/kie-wb-common/commit/8125e298cb4f65787e688659afe58189cff70b85#diff-5043480836f5a8381d4aeced0fb90d8fR342

It also uses the "package name white-list" for filtering classes

(a) Added to the DataModelOracle - which contains the meta-data for classes available for authoring:

https://github.com/droolsjbpm/kie-wb-common/commit/8125e298cb4f65787e688659afe58189cff70b85#diff-37f1dae81fc151bee95c9e1ee6831b71R98

(b) Validated for integrity (i.e. the class can be loaded) - the source of the WARNs mentioned in the BZ:

https://github.com/droolsjbpm/kie-wb-common/commit/8125e298cb4f65787e688659afe58189cff70b85#diff-45fdd57129750eb9eb41a4a2f753303fR186

Ultimately the cause of the BZ is the User adding jbpm-executor as a dependency (see https://bugzilla.redhat.com/show_bug.cgi?id=1201853#c9). Even with the "package name white list" KIE's KieModuleMetaData.Factory.newKieModuleMetaData(...) still resolves all classes in the KIE Project from all direct and indirect dependencies in the pom... so "package name white-list" makes some aspects quicker but not all. 

https://github.com/droolsjbpm/kie-wb-common/blob/master/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceImpl.java#L1214