### PR TITLE
Fix off-by-one error in NewResourcesMenu.

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenu.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenu.java
@@ -97,7 +97,7 @@ public class NewResourcesMenu {
     }
 
     public List<MenuItem> getMenuItemsWithoutProject() {
-        return items.subList( 1, items.size() - 1 );
+        return items.subList( 1, items.size() );
     }
 
     public void onProjectContextChanged( @Observes final ProjectContextChangeEvent event ) {


### PR DESCRIPTION
Found this small error while poking around. I believe `getMenuItemsWithoutProject` was only meant to filter out the first element of `items`.