### PR TITLE
Lock support for project editor

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenView.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenView.java
@@ -18,14 +18,16 @@ package org.kie.workbench.common.screens.projecteditor.client.editor;
 
 import java.util.List;
 
-import com.github.gwtbootstrap.client.ui.DropdownButton;
-import com.google.gwt.user.client.ui.IsWidget;
 import org.guvnor.common.services.project.model.Dependency;
 import org.guvnor.common.services.project.model.POM;
 import org.guvnor.common.services.project.model.ProjectImports;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.kie.workbench.common.services.shared.kmodule.KModuleModel;
 import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
+
+import com.github.gwtbootstrap.client.ui.DropdownButton;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 
 public interface ProjectScreenView
         extends HasBusyIndicator,
@@ -76,18 +78,32 @@ public interface ProjectScreenView
     void setImportsMetadata( Metadata projectImportsMetadata );
 
     void showImportsPanel();
+    
+    boolean showsImportsPanel();
 
     void showImportsMetadataPanel();
+    
+    boolean showsImportsMetadataPanel();
 
     void showDependenciesPanel();
+    
+    boolean showsDependenciesPanel();
 
     void showGAVMetadataPanel();
+    
+    boolean showsGAVMetadataPanel();
 
     void showGAVPanel();
+    
+    boolean showsGAVPanel();
 
     void showKBasePanel();
+    
+    boolean showsKBasePanel();
 
     void showKBaseMetadataPanel();
+    
+    boolean showsKBaseMetadataPanel();
 
     void switchBusyIndicator( String newMessage );
 
@@ -108,5 +124,19 @@ public interface ProjectScreenView
     void setValidArtifactID( boolean isValid );
 
     void setValidVersion( boolean isValid );
+    
+    Widget getPomPart();
+    
+    Widget getDependenciesPart();
+    
+    Widget getPomMetadataPart();
+    
+    Widget getImportsPart();
+    
+    Widget getImportsMetadataPart();
+    
+    Widget getKModulePart();
+    
+    Widget getKModuleMetadataPart();
 
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenViewImpl.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.screens.projecteditor.client.editor;
 
 import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -37,6 +38,7 @@ import com.google.gwt.user.client.ui.DeckPanel;
 import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
+
 import org.guvnor.common.services.project.client.ArtifactIdChangeHandler;
 import org.guvnor.common.services.project.client.GroupIdChangeHandler;
 import org.guvnor.common.services.project.client.POMEditorPanel;
@@ -433,4 +435,75 @@ public class ProjectScreenViewImpl
         container.setPixelSize(width,
                                height);
     }
+
+    @Override
+    public Widget getPomPart() {
+        return pomEditorPanel.asWidget();
+    }
+
+    @Override
+    public Widget getImportsPart() {
+        return importsWidgetPresenter.asWidget();
+    }
+
+    @Override
+    public Widget getKModulePart() {
+        return kModuleEditorPanel.asWidget();
+    }
+
+    @Override
+    public Widget getDependenciesPart() {
+        return dependencyGrid.asWidget();
+    }
+
+    @Override
+    public Widget getPomMetadataPart() {
+        return pomMetadataWidget;
+    }
+
+    @Override
+    public Widget getImportsMetadataPart() {
+        return importsPageMetadata;
+    }
+
+    @Override
+    public Widget getKModuleMetadataPart() {
+        return kModuleMetaDataPanel;
+    }
+
+    @Override
+    public boolean showsImportsPanel() {
+        return IMPORTS_PANEL_INDEX == deckPanel.getVisibleWidget();
+    }
+
+    @Override
+    public boolean showsImportsMetadataPanel() {
+        return IMPORTS_METADATA_PANEL_INDEX == deckPanel.getVisibleWidget();
+    }
+
+    @Override
+    public boolean showsDependenciesPanel() {
+        return DEPENDENCY_PANEL_INDEX == deckPanel.getVisibleWidget();
+    }
+
+    @Override
+    public boolean showsGAVMetadataPanel() {
+        return GAV_METADATA_PANEL_INDEX == deckPanel.getVisibleWidget();
+    }
+
+    @Override
+    public boolean showsGAVPanel() {
+        return GAV_PANEL_INDEX == deckPanel.getVisibleWidget();
+    }
+
+    @Override
+    public boolean showsKBasePanel() {
+        return KBASE_PANEL_INDEX == deckPanel.getVisibleWidget();
+    }
+
+    @Override
+    public boolean showsKBaseMetadataPanel() {
+        return KBASE_METADATA_PANEL_INDEX == deckPanel.getVisibleWidget();
+    }
+    
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/CRUDListBox.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/CRUDListBox.java
@@ -21,8 +21,10 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
+
 import org.kie.workbench.common.widgets.client.popups.text.PopupSetFieldCommand;
 import org.kie.workbench.common.widgets.client.popups.text.TextBoxFormPopup;
+import org.uberfire.client.mvp.LockRequiredEvent;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -37,6 +39,9 @@ public class CRUDListBox
     private CRUDListBoxView view;
     private TextBoxFormPopup newItemPopup;
 
+    @Inject
+    javax.enterprise.event.Event<LockRequiredEvent> lockRequired;
+    
     public CRUDListBox() {
     }
 
@@ -56,6 +61,7 @@ public class CRUDListBox
             public void setName(String name) {
                 view.addItemAndFireEvent(name);
                 newItemPopup.hide();
+                fireLockRequiredEvent();
             }
         });
     }
@@ -64,6 +70,7 @@ public class CRUDListBox
     public void onDelete() {
         if (view.getSelectedItem() != null) {
             view.removeItem(view.getSelectedItem());
+            fireLockRequiredEvent();
         }
     }
 
@@ -101,5 +108,11 @@ public class CRUDListBox
 
     public void clear() {
         view.clear();
+    }
+    
+    private void fireLockRequiredEvent() {
+        if (lockRequired != null) {
+            lockRequired.fire( new LockRequiredEvent() );
+        }
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/CRUDListBoxViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/CRUDListBoxViewImpl.java
@@ -51,7 +51,7 @@ public class CRUDListBoxViewImpl
 
     @UiField
     ListBox listBox;
-
+    
     @Inject
     public CRUDListBoxViewImpl() {
         initWidget(uiBinder.createAndBindUi(this));
@@ -124,4 +124,5 @@ public class CRUDListBoxViewImpl
     public void onDelete(ClickEvent clickEvent) {
         presenter.onDelete();
     }
+    
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/DependencySelectorPopupViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/DependencySelectorPopupViewImpl.java
@@ -1,11 +1,14 @@
 package org.kie.workbench.common.screens.projecteditor.client.forms;
 
 import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
 import com.github.gwtbootstrap.client.ui.event.ShownEvent;
 import com.github.gwtbootstrap.client.ui.event.ShownHandler;
+
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.container.IOC;
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.mvp.ParameterizedCommand;
 
@@ -16,6 +19,9 @@ public class DependencySelectorPopupViewImpl
 
     private DependencySelectorPresenter presenter;
     private DependencyListWidget dependencyPagedJarTable;
+    
+    @Inject
+    private javax.enterprise.event.Event<LockRequiredEvent> lockRequired;
 
     @AfterInitialization
     public void init() {
@@ -25,6 +31,7 @@ public class DependencySelectorPopupViewImpl
             @Override
             public void execute( String parameter ) {
                 presenter.onPathSelection( parameter );
+                lockRequired.fire( new LockRequiredEvent() );
             }
         } );
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/KSessionModelOptionsPopUp.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/KSessionModelOptionsPopUp.java
@@ -18,7 +18,6 @@ package org.kie.workbench.common.screens.projecteditor.client.forms;
 
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.Scheduler;
 import org.kie.workbench.common.services.shared.kmodule.KSessionModel;
 
 public class KSessionModelOptionsPopUp {

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/KSessionModelOptionsPopUpViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/KSessionModelOptionsPopUpViewImpl.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.screens.projecteditor.client.forms;
 
 import java.util.List;
+
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
@@ -25,8 +26,10 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Widget;
+
 import org.guvnor.common.services.project.model.WorkItemHandlerModel;
 import org.kie.workbench.common.services.shared.kmodule.ListenerModel;
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKButton;
 
@@ -47,6 +50,10 @@ public class KSessionModelOptionsPopUpViewImpl
 
     @UiField(provided = true)
     WorkItemHandlersPanel workItemHandlersPanel;
+    
+    @Inject
+    private javax.enterprise.event.Event<LockRequiredEvent> lockRequired;
+    
 
     @Inject
     public KSessionModelOptionsPopUpViewImpl(ListenersPanel listenersPanel,
@@ -59,6 +66,7 @@ public class KSessionModelOptionsPopUpViewImpl
             @Override
             public void execute() {
                 hide();
+                lockRequired.fire( new LockRequiredEvent() );
             }
         }));
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/KSessionsPanel.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/KSessionsPanel.java
@@ -17,14 +17,17 @@
 package org.kie.workbench.common.screens.projecteditor.client.forms;
 
 import java.util.List;
+
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
+
 import org.kie.workbench.common.services.shared.kmodule.KSessionModel;
 import org.kie.workbench.common.screens.projecteditor.client.widgets.XsdIDValidator;
 import org.kie.workbench.common.widgets.client.popups.text.PopupSetFieldCommand;
 import org.kie.workbench.common.widgets.client.popups.text.TextBoxFormPopup;
+import org.uberfire.client.mvp.LockRequiredEvent;
 
 public class KSessionsPanel
         implements KSessionsPanelView.Presenter,
@@ -33,6 +36,9 @@ public class KSessionsPanel
     private final KSessionsPanelView view;
     private final TextBoxFormPopup namePopup;
     private List<KSessionModel> items;
+    
+    @Inject
+    private javax.enterprise.event.Event<LockRequiredEvent> lockRequired;
 
     @Inject
     public KSessionsPanel(
@@ -67,6 +73,7 @@ public class KSessionsPanel
 
                     namePopup.setOldName("");
                     namePopup.hide();
+                    lockRequired.fire( new LockRequiredEvent() );
                 } else {
                     view.showXsdIDError();
                 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/widgets/ListFormComboPanel.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/widgets/ListFormComboPanel.java
@@ -18,11 +18,15 @@ package org.kie.workbench.common.screens.projecteditor.client.widgets;
 
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
+
 import org.guvnor.common.services.project.model.HasListFormComboPanelProperties;
 import org.kie.workbench.common.widgets.client.popups.text.FormPopup;
 import org.kie.workbench.common.widgets.client.popups.text.PopupSetFieldCommand;
+import org.uberfire.client.mvp.LockRequiredEvent;
 
 public abstract class ListFormComboPanel<T extends HasListFormComboPanelProperties>
         implements IsWidget, ListFormComboPanelView.Presenter {
@@ -33,6 +37,9 @@ public abstract class ListFormComboPanel<T extends HasListFormComboPanelProperti
 
     private String selectedItemName = null;
     private final Form<T> form;
+
+    @Inject
+    private javax.enterprise.event.Event<LockRequiredEvent> lockRequired;
 
     public ListFormComboPanel(ListFormComboPanelView view,
             Form<T> form,
@@ -82,6 +89,7 @@ public abstract class ListFormComboPanel<T extends HasListFormComboPanelProperti
                     setSelected(model);
 
                     namePopup.hide();
+                    fireLockRequiredEvent();
                 }
             }
         });
@@ -106,6 +114,7 @@ public abstract class ListFormComboPanel<T extends HasListFormComboPanelProperti
                     setSelected(model);
 
                     namePopup.hide();
+                    fireLockRequiredEvent();
                 } else {
                     view.showXsdIDError();
                 }
@@ -148,6 +157,7 @@ public abstract class ListFormComboPanel<T extends HasListFormComboPanelProperti
 
     @Override
     public void onRemove() {
+        fireLockRequiredEvent();
         if (selectedItemName == null) {
             view.showPleaseSelectAnItem();
         } else {
@@ -162,6 +172,7 @@ public abstract class ListFormComboPanel<T extends HasListFormComboPanelProperti
 
     @Override
     public void onMakeDefault() {
+        fireLockRequiredEvent();
         if (selectedItemName == null) {
             view.showPleaseSelectAnItem();
         } else {
@@ -170,6 +181,12 @@ public abstract class ListFormComboPanel<T extends HasListFormComboPanelProperti
             }
             items.get(selectedItemName).setDefault(true);
             view.disableMakeDefault();
+        }
+    }
+    
+    private void fireLockRequiredEvent() {
+        if (lockRequired != null) {
+            lockRequired.fire( new LockRequiredEvent() );
         }
     }
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetViewImpl.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.widgets.configresource.client.widget.bound;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.inject.Inject;
 
 import com.github.gwtbootstrap.client.ui.Button;
@@ -40,10 +41,12 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+
 import org.drools.workbench.models.datamodel.imports.Import;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 import org.kie.workbench.common.widgets.configresource.client.resources.i18n.ImportConstants;
 import org.kie.workbench.common.widgets.metadata.client.KieEditorViewImpl;
+import org.uberfire.client.mvp.LockRequiredEvent;
 
 public class ImportsWidgetViewImpl
         extends KieEditorViewImpl
@@ -64,6 +67,9 @@ public class ImportsWidgetViewImpl
 
     @Inject
     private AddImportPopup addImportPopup;
+    
+    @Inject
+    private javax.enterprise.event.Event<LockRequiredEvent> lockRequired;
 
     private List<Import> importTypes = new ArrayList<Import>();
     private List<Import> allAvailableImportTypes = new ArrayList<Import>();
@@ -161,6 +167,7 @@ public class ImportsWidgetViewImpl
             public void execute() {
                 final Import importType = new Import( addImportPopup.getImportType() );
                 dataProvider.getList().add( importType );
+                lockRequired.fire( new LockRequiredEvent() );
                 presenter.onAddImport( importType );
             }
         };

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/unbound/ImportsWidgetViewImpl.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.widgets.configresource.client.widget.unbound;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.inject.Inject;
 
 import com.github.gwtbootstrap.client.ui.Button;
@@ -41,8 +42,10 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.view.client.ListDataProvider;
+
 import org.drools.workbench.models.datamodel.imports.Import;
 import org.kie.workbench.common.widgets.configresource.client.resources.i18n.ImportConstants;
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 
 public class ImportsWidgetViewImpl
@@ -64,6 +67,9 @@ public class ImportsWidgetViewImpl
 
     @Inject
     private AddImportPopup addImportPopup;
+    
+    @Inject
+    private javax.enterprise.event.Event<LockRequiredEvent> lockRequired;
 
     private List<Import> importTypes = new ArrayList<Import>();
     private ListDataProvider<Import> dataProvider = new ListDataProvider<Import>();
@@ -156,6 +162,7 @@ public class ImportsWidgetViewImpl
             public void execute() {
                 final Import importType = new Import( addImportPopup.getImportType() );
                 dataProvider.getList().add( importType );
+                lockRequired.fire( new LockRequiredEvent() );
             }
         };
     }


### PR DESCRIPTION
Hi @manstis, @Rikkola,

This PR adds lock support to the project editor. The locks are fine-grained so that one user editing the dependencies doesn't stop others from modifying imports or the kmodule settings.

This is a minimally invasive change and doesn't affect the existing project editor design i.e. it doesn't convert it to a workbench editor or use nested editors. It does work fine and since we need a solution soon it seems we can postpone the bigger refactoring, if still desired.

Cheers,
Christian