### PR TITLE
Dynamically Load Additional Build Options in Project Screen

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
@@ -195,7 +195,7 @@ public class ProjectScreenPresenter
         this.buildOptions = view.getBuildOptionsButton();
 
         makeMenuBar();
-        
+
         reloadRunnable = new Runnable() {
 
             @Override
@@ -203,7 +203,7 @@ public class ProjectScreenPresenter
                 ProjectScreenPresenter.this.reload();
             }
         };
-        
+
         titleProvider = new TitleProvider() {
 
             @Override
@@ -295,7 +295,7 @@ public class ProjectScreenPresenter
         this.placeRequest = placeRequest;
         update();
     }
-    
+
     @OnMayClose
     public boolean onMayClose() {
         if (isDirty()) {
@@ -311,7 +311,7 @@ public class ProjectScreenPresenter
             lockManager.releaseLock();
         }
     }
-    
+
     private void update() {
         if (workbenchContext.getActiveProject() == null) {
             disableMenus();
@@ -400,12 +400,12 @@ public class ProjectScreenPresenter
                 model.getPOM().getGav().getArtifactId() + ":" +
                         model.getPOM().getGav().getGroupId() + ":" +
                         model.getPOM().getGav().getVersion() );
-        
+
         changeTitleWidgetEvent.fire( new ChangeTitleWidgetEvent(
                 placeRequest,
                 title ) );
     }
-    
+
     private void updateCurrentView() {
         if ( view.showsGAVPanel() ) {
             onGAVPanelSelected();
@@ -421,7 +421,7 @@ public class ProjectScreenPresenter
         }
         else if ( view.showsKBasePanel() ) {
             onKBasePanelSelected();
-        } 
+        }
         else if ( view.showsKBaseMetadataPanel() ) {
             onKBaseMetadataPanelSelected();
         }
@@ -1046,14 +1046,14 @@ public class ProjectScreenPresenter
             }
         } ).validateVersion( version );
     }
-    
+
     private void acquireLockOnDemand(final Path path, final Widget widget) {
         final LockManager lockManager = getOrCreateLockManager( widget );
         final LockTarget lockTarget = new LockTarget(path, widget, placeRequest, titleProvider, reloadRunnable );
         lockManager.init( lockTarget );
         lockManager.acquireLockOnDemand();
     }
-    
+
     private LockManager getOrCreateLockManager(final Widget widget) {
         LockManager lockManager = lockManagers.get( widget );
         if (lockManager == null) {
@@ -1062,5 +1062,5 @@ public class ProjectScreenPresenter
         }
         return lockManager;
     }
-    
+
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
@@ -1012,10 +1012,8 @@ public class ProjectScreenPresenter
     }
 
     private void enableBuildAndDeploy( boolean enabled ) {
-        if ( Boolean.TRUE.equals( ApplicationPreferences.getBooleanPref( "support.runtime.deploy" ) ) &&
-                buildOptions.getMenuWiget().getWidgetCount() > 1 ) {
+        if ( Boolean.TRUE.equals( ApplicationPreferences.getBooleanPref( "support.runtime.deploy" ) )) {
             buildOptions.getMenuWiget().getWidget( 2 ).setVisible( enabled );
-
         }
     }
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/extension/BuildOptionExtension.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/extension/BuildOptionExtension.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.editor.extension;
+
+import java.util.Collection;
+
+import org.guvnor.common.services.project.model.Project;
+
+import com.google.gwt.user.client.ui.Widget;
+
+
+public interface BuildOptionExtension {
+
+    Collection<Widget> getBuildOptions( Project project );
+
+}


### PR DESCRIPTION
This PR adds extensibility to the `ProjectScreenPresenter` so that other modules can implement additional build options in the build drop down.

The motivation for this change comes from LiveSpark, where we want to offer to different kinds of build/deployment for production and development.