### PR TITLE
Kie builder optimizations

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/LRUBuilderCache.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/LRUBuilderCache.java
@@ -62,6 +62,10 @@ public class LRUBuilderCache extends LRUCache<Project, Builder> {
     @Named("LRUProjectDependenciesClassLoaderCache")
     private LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache;
 
+    @Inject
+    @Named("LRUPomModelCache")
+    private LRUPomModelCache pomModelCache;
+
     private final List<BuildValidationHelper> buildValidationHelpers = new ArrayList<BuildValidationHelper>();
 
     @PostConstruct
@@ -92,7 +96,8 @@ public class LRUBuilderCache extends LRUCache<Project, Builder> {
                                    importsService,
                                    buildValidationHelpers,
                                    packageNameWhiteList,
-                                   dependenciesClassLoaderCache );
+                                   dependenciesClassLoaderCache,
+                                   pomModelCache );
 
             setEntry( project,
                       builder );

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/LRUPomModelCache.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/LRUPomModelCache.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.backend.builder;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.drools.compiler.kproject.xml.PomModel;
+import org.guvnor.common.services.backend.cache.LRUCache;
+import org.guvnor.common.services.builder.ObservablePOMFile;
+import org.guvnor.common.services.project.builder.events.InvalidateDMOProjectCacheEvent;
+import org.guvnor.common.services.project.model.Project;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+@ApplicationScoped
+@Named("LRUPomModelCache")
+public class LRUPomModelCache extends LRUCache<Project, PomModel> {
+
+    @Inject
+    private ObservablePOMFile observablePOMFile;
+
+    public synchronized void invalidateProjectCache( @Observes final InvalidateDMOProjectCacheEvent event ) {
+        PortablePreconditions.checkNotNull( "event",
+                event );
+
+        if ( event.getResourcePath() != null &&
+             event.getProject() != null &&
+             observablePOMFile.accept( event.getResourcePath().getFileName() ) ) {
+            invalidateCache( event.getProject() );
+        }
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuildServiceImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuildServiceImplTest.java
@@ -53,6 +53,7 @@ public class BuildServiceImplTest
         KieProjectService projectService = getReference( KieProjectService.class );
         ProjectImportsService importsService = getReference( ProjectImportsService.class );
         LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache = getReference( LRUProjectDependenciesClassLoaderCache.class );
+        LRUPomModelCache pomModelCache = getReference( LRUPomModelCache.class );
 
         URL url = this.getClass().getResource( "/GuvnorM2RepoDependencyExample1" );
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
@@ -66,7 +67,8 @@ public class BuildServiceImplTest
                                              importsService,
                                              new ArrayList<BuildValidationHelper>(),
                                              new PackageNameWhiteList( ioService ),
-                                             dependenciesClassLoaderCache );
+                                             dependenciesClassLoaderCache,
+                                             pomModelCache );
 
         final BuildResults results = builder.build();
 
@@ -79,6 +81,7 @@ public class BuildServiceImplTest
         KieProjectService projectService = getReference( KieProjectService.class );
         ProjectImportsService importsService = getReference( ProjectImportsService.class );
         LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache = getReference( LRUProjectDependenciesClassLoaderCache.class );
+        LRUPomModelCache pomModelCache = getReference( LRUPomModelCache.class );
 
         URL url = this.getClass().getResource( "/GuvnorM2RepoDependencyExample2" );
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
@@ -92,7 +95,8 @@ public class BuildServiceImplTest
                                              importsService,
                                              new ArrayList<BuildValidationHelper>(),
                                              new PackageNameWhiteList( ioService ),
-                                             dependenciesClassLoaderCache );
+                                             dependenciesClassLoaderCache,
+                                             pomModelCache );
 
         final BuildResults results = builder.build();
 
@@ -112,6 +116,7 @@ public class BuildServiceImplTest
         KieProjectService projectService = getReference( KieProjectService.class );
         ProjectImportsService importsService = getReference( ProjectImportsService.class );
         LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache = getReference( LRUProjectDependenciesClassLoaderCache.class );
+        LRUPomModelCache pomModelCache = getReference( LRUPomModelCache.class );
 
         URL url = this.getClass().getResource( "/GuvnorM2RepoDependencyExample2Snapshot" );
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
@@ -125,7 +130,8 @@ public class BuildServiceImplTest
                                              importsService,
                                              new ArrayList<BuildValidationHelper>(),
                                              new PackageNameWhiteList( ioService ),
-                                             dependenciesClassLoaderCache );
+                                             dependenciesClassLoaderCache,
+                                             pomModelCache );
 
         final BuildResults results = builder.build();
 
@@ -145,6 +151,7 @@ public class BuildServiceImplTest
         KieProjectService projectService = getReference( KieProjectService.class );
         ProjectImportsService importsService = getReference( ProjectImportsService.class );
         LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache = getReference( LRUProjectDependenciesClassLoaderCache.class );
+        LRUPomModelCache pomModelCache = getReference( LRUPomModelCache.class );
 
         URL url = this.getClass().getResource( "/GuvnorM2RepoDependencyExample2" );
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
@@ -158,7 +165,8 @@ public class BuildServiceImplTest
                                              importsService,
                                              new ArrayList<BuildValidationHelper>(),
                                              new PackageNameWhiteList( ioService ),
-                                             dependenciesClassLoaderCache );
+                                             dependenciesClassLoaderCache,
+                                             pomModelCache );
 
         final BuildResults results = builder.build();
 
@@ -206,6 +214,7 @@ public class BuildServiceImplTest
         KieProjectService projectService = getReference( KieProjectService.class );
         ProjectImportsService importsService = getReference( ProjectImportsService.class );
         LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache = getReference( LRUProjectDependenciesClassLoaderCache.class );
+        LRUPomModelCache pomModelCache = getReference( LRUPomModelCache.class );
 
         URL url = this.getClass().getResource( "/ExampleWithExcel" );
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
@@ -219,7 +228,8 @@ public class BuildServiceImplTest
                                              importsService,
                                              new ArrayList<BuildValidationHelper>(),
                                              new PackageNameWhiteList( ioService ),
-                                             dependenciesClassLoaderCache );
+                                             dependenciesClassLoaderCache,
+                                             pomModelCache );
 
         final BuildResults results = builder.build();
 

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuilderTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuilderTest.java
@@ -47,6 +47,7 @@ public class BuilderTest
         KieProjectService projectService = getReference( KieProjectService.class );
         ProjectImportsService importsService = getReference( ProjectImportsService.class );
         LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache = getReference( LRUProjectDependenciesClassLoaderCache.class );
+        LRUPomModelCache pomModelCache = getReference( LRUPomModelCache.class );
 
         URL url = this.getClass().getResource( "/GuvnorM2RepoDependencyExample1" );
         SimpleFileSystemProvider p = new SimpleFileSystemProvider();
@@ -60,7 +61,8 @@ public class BuilderTest
                                              importsService,
                                              new ArrayList<BuildValidationHelper>(),
                                              new PackageNameWhiteList( ioService ),
-                                             dependenciesClassLoaderCache );
+                                             dependenciesClassLoaderCache,
+                                             pomModelCache );
 
         assertNotNull( builder.getKieContainer() );
     }
@@ -72,6 +74,7 @@ public class BuilderTest
         KieProjectService projectService = getReference( KieProjectService.class );
         ProjectImportsService importsService = getReference( ProjectImportsService.class );
         LRUProjectDependenciesClassLoaderCache dependenciesClassLoaderCache = getReference( LRUProjectDependenciesClassLoaderCache.class );
+        LRUPomModelCache pomModelCache = getReference( LRUPomModelCache.class );
 
         SimpleFileSystemProvider provider = new SimpleFileSystemProvider();
         org.uberfire.java.nio.file.Path path = provider.getPath( this.getClass().getResource( "/BuilderExampleBrokenSyntax" ).toURI() );
@@ -84,7 +87,8 @@ public class BuilderTest
                                              importsService,
                                              new ArrayList<BuildValidationHelper>(),
                                              new PackageNameWhiteList( ioService ),
-                                             dependenciesClassLoaderCache );
+                                             dependenciesClassLoaderCache,
+                                             pomModelCache );
 
         assertNull( builder.getKieContainer() );
 


### PR DESCRIPTION
The optimization includes the caching of the PomModel for a given project.
The PomModel will be reused whenever it's possible for the KieBuilder creation, this will reduce the KieBuilder initialization procedure given that the pom.xml parsing with the subsecuent dependencies calculation will be skipped.
