### PR TITLE
Fix indexing tests by disabling Git daemon and ssh

### DIFF
--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/BaseIndexingTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/BaseIndexingTest.java
@@ -39,6 +39,12 @@ public abstract class BaseIndexingTest<T extends ResourceTypeDefinition> extends
             final String path = createTempDirectory().getAbsolutePath();
             System.setProperty( "org.uberfire.nio.git.dir",
                                 path );
+            System.setProperty( "org.uberfire.nio.git.daemon.enabled",
+                                "false" );
+            System.setProperty( "org.uberfire.nio.git.ssh.enabled",
+                                "false" );
+            System.setProperty( "org.uberfire.sys.repo.monitor.disabled",
+                                "true" );
             System.out.println( ".niogit: " + path );
 
             final URI newRepo = URI.create( "git://" + repositoryName );


### PR DESCRIPTION
 * this fixes a lot of test failures in drools-wb
   (when running the tests in parallel)