### PR TITLE
Make business/technial views of PEX consistent

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/ExplorerViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/ExplorerViewImpl.java
@@ -24,6 +24,7 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiFactory;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
+import org.kie.workbench.common.screens.explorer.client.utils.IdHelper;
 import org.kie.workbench.common.screens.explorer.client.widgets.business.BusinessViewWidget;
 import org.kie.workbench.common.screens.explorer.client.widgets.technical.TechnicalViewWidget;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
@@ -56,6 +57,7 @@ public class ExplorerViewImpl extends Composite implements ExplorerView {
         initWidget( uiBinder.createAndBindUi( this ) );
 
         getElement().getStyle().setPropertyPx( "minWidth", 370 );
+        IdHelper.setId(this, "pex_content_");
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/utils/IdHelper.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/utils/IdHelper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.explorer.client.utils;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.user.client.ui.UIObject;
+
+public class IdHelper {
+
+    /**
+     * Setting ID on gwt UIObjects for selenium tests.
+     *
+     * @param obj
+     * @param prefix
+     */
+    public static void setId(UIObject obj, String prefix) {
+        obj.getElement().setId(prefix + Document.get().createUniqueId());
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
@@ -65,7 +65,6 @@ import org.kie.workbench.common.screens.explorer.model.FolderItem;
 import org.kie.workbench.common.screens.explorer.model.FolderItemType;
 import org.kie.workbench.common.screens.explorer.model.FolderListing;
 import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
-import org.kie.workbench.common.screens.explorer.service.Option;
 import org.kie.workbench.common.screens.explorer.utils.Sorters;
 import org.kie.workbench.common.services.shared.project.KieProject;
 import org.uberfire.client.mvp.PlaceManager;

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.ui.xml
@@ -22,16 +22,12 @@
              xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
              xmlns:bootstrap="urn:import:com.github.gwtbootstrap.client.ui">
 
-  <ui:with field="resources"
-           type="org.kie.workbench.common.screens.explorer.client.resources.ProjectExplorerResources"/>
-  <ui:with field="i18n"
-           type="org.kie.workbench.common.screens.explorer.client.resources.i18n.ProjectExplorerConstants"/>
+  <ui:with field="resources" type="org.kie.workbench.common.screens.explorer.client.resources.ProjectExplorerResources"/>
+  <ui:with field="i18n" type="org.kie.workbench.common.screens.explorer.client.resources.i18n.ProjectExplorerConstants"/>
 
   <gwt:HTMLPanel visible="true">
     <div ui:field="businessView">
       <bootstrap:Well styleName="{resources.CSS.viewContainer}">
-        <w:Explorer ui:field="explorer"/>
-        <hr/>
         <bootstrap:Button ui:field="openProjectEditorButton">
           <ui:text from="{i18n.openProjectEditor}"/>
         </bootstrap:Button>
@@ -39,6 +35,7 @@
         <hr/>
         <div style="clear:both;" />
         <tagSelector:TagSelector ui:field="tagSelector"></tagSelector:TagSelector>
+        <w:Explorer ui:field="explorer"/>
         <bootstrap:WellNavList ui:field="itemsContainer"/>
       </bootstrap:Well>
     </div>

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/Explorer.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/Explorer.java
@@ -36,6 +36,7 @@ import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.repositories.Repository;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.kie.workbench.common.screens.explorer.client.resources.i18n.ProjectExplorerConstants;
+import org.kie.workbench.common.screens.explorer.client.utils.IdHelper;
 import org.kie.workbench.common.screens.explorer.client.widgets.ViewPresenter;
 import org.kie.workbench.common.screens.explorer.client.widgets.dropdown.CustomDropdown;
 import org.kie.workbench.common.screens.explorer.model.FolderItem;
@@ -70,6 +71,7 @@ public class Explorer extends Composite {
 
     public Explorer() {
         initWidget( container );
+        IdHelper.setId(container, "pex_nav_");
         setStyleName( NavigatorResources.INSTANCE.css().container() );
     }
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.ui.xml
@@ -27,14 +27,14 @@
 
   <g:HTMLPanel visible="false">
     <div ui:field="technicalView">
-        <b:Button ui:field="openProjectEditorButton"  >
-             <ui:text from="{i18n.openProjectEditor}"/>
-        </b:Button>
-        <selector:BranchSelector ui:field="branchSelector" />
-        <hr/>
-        <div style="clear:both;" />
-        <tagSelector:TagSelector ui:field="tagSelector"></tagSelector:TagSelector>
-        <w:Explorer ui:field="explorer"/>
+      <b:Button ui:field="openProjectEditorButton"  >
+        <ui:text from="{i18n.openProjectEditor}"/>
+      </b:Button>
+      <selector:BranchSelector ui:field="branchSelector" />
+      <hr/>
+      <div style="clear:both;" />
+      <tagSelector:TagSelector ui:field="tagSelector"></tagSelector:TagSelector>
+      <w:Explorer ui:field="explorer"/>
     </div>
   </g:HTMLPanel>
 


### PR DESCRIPTION
..and add some IDs for selenium testing

The only substantial change is reordering of Project explorer's controls in BusinessViewWidget.ui.xml to be consistent with TechnicalViewWidget.ui.xml (see screenshot before and after change https://ctrlv.cz/Z3dA)

In addition to that I added some DOM IDs that will make maintenance of our selenium tests easier. It's much easier for us to maintain relatively stable locators ala "div[id^='pex_content']" than having to update brittle locators like "div div[aria-hidden=true]+div>div>div>div>div>div:not([aria-hidden=true])" after every change done to the view.