### PR TITLE
JBPM-4625 Generation of JPA enabled models

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
@@ -765,6 +765,7 @@ public class DataModelerScreenPresenter
                 }
 
                 dataModelerWBContext.setActiveContext( context );
+                showDataModellerDocks();
                 createOriginalHash( context.getDataObject() );
                 originalSourceHash = getSource().hashCode();
                 loading = false;


### PR DESCRIPTION
- Complementary fix to Eder's "Hide docks when you put data modeler in background".