### PR TITLE
BZ1263454: Unable to create Project in cloned Git Repository

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewProjectHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewProjectHandler.java
@@ -94,8 +94,10 @@ public class NewProjectHandler
 
                 @Override
                 public void callback( RepositoryStructureModel repoModel ) {
-                    if ( repoModel.isManaged() ) {
-                        wizard.setContent( projectName, repoModel.getPOM().getGav().getGroupId(), repoModel.getPOM().getGav().getVersion() );
+                    if ( repoModel != null && repoModel.isManaged() ) {
+                        wizard.setContent( projectName,
+                                           repoModel.getPOM().getGav().getGroupId(),
+                                           repoModel.getPOM().getGav().getVersion() );
                     } else {
                         wizard.setContent( projectName );
                     }


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1263454

The problem was that the ```CreateRepositoryForm``` did not set the repository to be "unmanaged".

I fixed that in ```guvnor``` (and moved the constants in ```EnvironmentParameters``` to the ```-api``` module to allow re-use of the constants on both the server and client - as it had been duplicated in ```CreateRepositoryWizard```). 

I took the precaution of checking if ```RepositoryStructureModel``` is null in the ```NewProjectHandler``` in ```kie-wb-common``` too).