### PR TITLE
JBPM-4777-Data Modeller fixes after the BS3 migration

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/PrimitivesAnnotation.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/PrimitivesAnnotation.java
@@ -27,39 +27,39 @@ import java.lang.annotation.RetentionPolicy;
 @java.lang.annotation.Target({ ElementType.TYPE, ElementType.FIELD })
 public @interface PrimitivesAnnotation {
 
-    byte byteParam() default 0;
+    byte byteParam() ; //default 0;
 
-    byte[] byteArrayParam() default {};
+    byte[] byteArrayParam() ; //default {};
 
-    short shortParam() default 0;
+    short shortParam() ; //default 0;
 
-    short[] shortArrayParam() default {};
+    short[] shortArrayParam() ; //default {};
 
-    int intParam() default 0;
+    int intParam() ;//default 0;
 
-    int[] intArrayParam() default {};
+    int[] intArrayParam() ;//default {};
 
-    long longParam() default 0;
+    long longParam() ;//default 0;
 
-    long[] longArrayParam() default {};
+    long[] longArrayParam();// default {};
 
-    float floatParam() default 0.0f;
+    float floatParam();// default 0.0f;
 
-    float[] floatArrayParam() default {};
+    float[] floatArrayParam() ;//default {};
 
-    double doubleParam() default 0.0;
+    double doubleParam() ;//default 0.0;
 
-    double[] doubleArrayParam() default {};
+    double[] doubleArrayParam() ;//default {};
 
-    boolean booleanParam() default false;
+    boolean booleanParam() ;//default false;
 
-    boolean[] booleanArrayParam() default {};
+    boolean[] booleanArrayParam();// default {};
 
-    char charParam() default '0';
+    char charParam() ;//default '0';
 
-    char[] charArrayParam() default {};
+    char[] charArrayParam() ;//default {};
 
-    String stringParam() default "";
+    String stringParam() ;//default "";
 
-    String[] stringArrayParam() default {};
+    String[] stringArrayParam(); // default {};
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationlisteditor/AdvancedAnnotationListEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationlisteditor/AdvancedAnnotationListEditorViewImpl.java
@@ -90,6 +90,9 @@ public class AdvancedAnnotationListEditorViewImpl
     private boolean readonly = false;
 
     @Inject
+    CreateAnnotationWizard createAnnotationWizard;
+
+    @Inject
     private SyncBeanManager iocManager;
 
     public AdvancedAnnotationListEditorViewImpl() {
@@ -159,6 +162,7 @@ public class AdvancedAnnotationListEditorViewImpl
         header.add( heading );
 
         accordionsContainer.add( container );
+        annotationAccordion.put( annotation, container );
 
         if ( annotation.getAnnotationDefinition() != null &&
                 annotation.getAnnotationDefinition().getValuePairs() != null ) {
@@ -262,17 +266,9 @@ public class AdvancedAnnotationListEditorViewImpl
     public void invokeCreateAnnotationWizard( final Callback<Annotation> callback,
                                               final KieProject kieProject,
                                               final ElementType elementType ) {
-        final CreateAnnotationWizard addAnnotationWizard = iocManager.lookupBean( CreateAnnotationWizard.class ).getInstance();
-        //When the wizard is closed destroy it to avoid memory leak
-        addAnnotationWizard.onCloseCallback( new Callback<Annotation>() {
-            @Override
-            public void callback( Annotation result ) {
-                iocManager.destroyBean( addAnnotationWizard );
-                callback.callback( result );
-            }
-        } );
-        addAnnotationWizard.init( kieProject, elementType );
-        addAnnotationWizard.start();
+        createAnnotationWizard.init( kieProject, elementType );
+        createAnnotationWizard.onCloseCallback( callback );
+        createAnnotationWizard.start();
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/CreateAnnotationWizard.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/CreateAnnotationWizard.java
@@ -22,6 +22,8 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.bus.client.api.messaging.Message;
@@ -85,6 +87,7 @@ public class CreateAnnotationWizard extends AbstractWizard {
         this.project = project;
         this.target = target;
         searchAnnotationPage.init( project, target );
+        clearCurrentValuePairEditorPages();
     }
 
     @Override
@@ -163,8 +166,16 @@ public class CreateAnnotationWizard extends AbstractWizard {
     }
 
     private void doOnSearchClassChanged() {
-        clearCurrentValuePairEditorPages();
-        super.start();
+        if ( annotationDefinition != null || pages.size() > 1 ) {
+            annotationDefinition = null;
+            clearCurrentValuePairEditorPages();
+            super.start();
+            Scheduler.get().scheduleDeferred( new Command() {
+                @Override public void execute() {
+                    searchAnnotationPage.requestFocus();
+                }
+            } );
+        }
     }
 
     private void updateValuePairPages( AnnotationDefinition annotationDefinition ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPage.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPage.java
@@ -52,6 +52,9 @@ public class SearchAnnotationPage
     public void init( KieProject project, ElementType target ) {
         this.project = project;
         this.target = target;
+        this.status = PageStatus.NOT_VALIDATED;
+        view.setClassName( null );
+        view.clearHelpMessage();
     }
 
     @Override
@@ -96,6 +99,10 @@ public class SearchAnnotationPage
             searchAnnotationHandler.onSearchClassChanged();
         }
         setStatus( PageStatus.NOT_VALIDATED );
+    }
+
+    public void requestFocus() {
+        view.setClassNameFocus( true );
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPageView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPageView.java
@@ -44,6 +44,8 @@ public interface SearchAnnotationPageView
 
     void setClassName( String className );
 
+    void setClassNameFocus( boolean focus );
+
     void clearHelpMessage();
 
     void setHelpMessage( String helpMessage );

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPageViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPageViewImpl.java
@@ -20,8 +20,8 @@ import javax.enterprise.context.Dependent;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
@@ -57,9 +57,10 @@ public class SearchAnnotationPageViewImpl
     public SearchAnnotationPageViewImpl() {
         initWidget( uiBinder.createAndBindUi( this ) );
         searchAnnotationButton.setTitle( Constants.INSTANCE.advanced_domain_wizard_search_page_search_button_tooltip() );
-        annotationClassName.addKeyDownHandler( new KeyDownHandler() {
+
+        annotationClassName.addKeyUpHandler( new KeyUpHandler() {
             @Override
-            public void onKeyDown( KeyDownEvent event ) {
+            public void onKeyUp( KeyUpEvent event ) {
                 presenter.onSearchClassChanged();
             }
         } );
@@ -78,6 +79,11 @@ public class SearchAnnotationPageViewImpl
     @Override
     public void setClassName( String className ) {
         annotationClassName.setText( className );
+    }
+
+    @Override
+    public void setClassNameFocus( boolean focus ) {
+        annotationClassName.setFocus( focus );
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPageViewImpl.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/annotationwizard/SearchAnnotationPageViewImpl.ui.xml
@@ -21,7 +21,7 @@
     <ui:with field="i18n" type="org.kie.workbench.common.screens.datamodeller.client.resources.i18n.Constants"/>
 
     <b:FormGroup ui:field="searchGroup">
-        <b:FormLabel for="className" showRequiredIndicator="true" text="Annotation class name" addStyleNames="col-md-5"/>
+        <b:FormLabel for="className" showRequiredIndicator="true" text="{i18n.advanced_domain_wizard_search_page_search_field}" addStyleNames="col-md-5"/>
 
         <b:Column size="MD_7">
             <b:InputGroup>

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/ValuePairEditorView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/ValuePairEditorView.java
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.string;
+package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor;
 
-import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditorView;
+import com.google.gwt.user.client.ui.IsWidget;
 
-public interface StringValuePairEditorView
-        extends ValuePairEditorView {
+public interface ValuePairEditorView
+        extends IsWidget {
 
-    interface Presenter {
+    void setValuePairLabel( String valuePairLabel );
 
-        void onValueChanged();
-    }
+    void showValuePairName( boolean show );
 
-    void setPresenter( Presenter presenter );
-
-    void setValue ( String value );
-
-    String getValue( );
-
-    void clear();
+    void showValuePairRequiredIndicator( boolean required );
 
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/booleans/BooleanValuePairEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/booleans/BooleanValuePairEditor.java
@@ -51,6 +51,7 @@ public class BooleanValuePairEditor
     public void init( AnnotationValuePairDefinition valuePairDefinition ) {
         this.valuePairDefinition = valuePairDefinition;
         view.setValuePairLabel( ValuePairEditorUtil.buildValuePairLabel( valuePairDefinition ) );
+        view.showValuePairRequiredIndicator( !valuePairDefinition.hasDefaultValue() );
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/booleans/BooleanValuePairEditorView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/booleans/BooleanValuePairEditorView.java
@@ -16,10 +16,10 @@
 
 package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.booleans;
 
-import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditorView;
 
 public interface BooleanValuePairEditorView
-        extends IsWidget {
+        extends ValuePairEditorView {
 
     String NOT_SELECTED = "_NOT_SELECTED_";
 
@@ -33,9 +33,5 @@ public interface BooleanValuePairEditorView
     void setSelectedValue( String value );
 
     String getSelectedValue();
-
-    void setValuePairLabel( String valuePairLabel );
-
-    void showValuePairName( boolean show );
 
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/booleans/BooleanValuePairEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/booleans/BooleanValuePairEditorViewImpl.java
@@ -49,6 +49,10 @@ public class BooleanValuePairEditorViewImpl
     @UiField
     Select listBox;
 
+    String currentValuePairLabel = null;
+
+    boolean showRequiredIndicator = true;
+
     private static List<Pair<String, String>> items = new ArrayList<Pair<String, String>>();
 
     static {
@@ -81,11 +85,26 @@ public class BooleanValuePairEditorViewImpl
 
     public void setValuePairLabel( String valuePairLabel ) {
         this.valuePairLabel.setText( valuePairLabel );
+        currentValuePairLabel = valuePairLabel;
     }
 
     @Override
     public void showValuePairName( boolean show ) {
-        this.valuePairLabel.setVisible( show );
+        if ( !show ) {
+            currentValuePairLabel = valuePairLabel.getText();
+            showRequiredIndicator = valuePairLabel.getShowRequiredIndicator();
+            valuePairLabel.setText( null );
+            valuePairLabel.setShowRequiredIndicator( false );
+        } else {
+            valuePairLabel.setText( currentValuePairLabel );
+            valuePairLabel.setShowRequiredIndicator( showRequiredIndicator );
+        }
+    }
+
+    @Override
+    public void showValuePairRequiredIndicator( boolean required ) {
+        this.valuePairLabel.setShowRequiredIndicator( required );
+        showRequiredIndicator = required;
     }
 
     private void initItems( List<Pair<String, String>> options ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/EnumValuePairEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/EnumValuePairEditor.java
@@ -56,6 +56,7 @@ public class EnumValuePairEditor
         this.valuePairDefinition = valuePairDefinition;
         view.initItems( createItemList( valuePairDefinition.getClassName(), valuePairDefinition.enumValues() ) );
         view.setValuePairLabel( ValuePairEditorUtil.buildValuePairLabel( valuePairDefinition ) );
+        view.showValuePairRequiredIndicator( !valuePairDefinition.hasDefaultValue() );
     }
 
     private List<Pair<String, String>> createItemList( String className, String[] enumValues ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/EnumValuePairEditorView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/EnumValuePairEditorView.java
@@ -18,11 +18,11 @@ package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddom
 
 import java.util.List;
 
-import com.google.gwt.user.client.ui.IsWidget;
+import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditorView;
 import org.uberfire.commons.data.Pair;
 
 public interface EnumValuePairEditorView
-        extends IsWidget {
+        extends ValuePairEditorView {
 
     String NOT_SELECTED = "_NOT_SELECTED_";
 
@@ -39,7 +39,5 @@ public interface EnumValuePairEditorView
     void setSelectedValue( String value );
 
     String getSelectedValue( );
-
-    void setValuePairLabel( String valuePairLabel );
 
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/EnumValuePairEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/EnumValuePairEditorViewImpl.java
@@ -76,8 +76,19 @@ public class EnumValuePairEditorViewImpl
         return listBox.getValue();
     }
 
+    @Override
     public void setValuePairLabel( String valuePairLabel ) {
         this.valuePairLabel.setText( valuePairLabel );
+    }
+
+    @Override
+    public void showValuePairName( boolean show ) {
+        this.valuePairLabel.setVisible( show );
+    }
+
+    @Override
+    public void showValuePairRequiredIndicator( boolean required ) {
+        this.valuePairLabel.setShowRequiredIndicator( required );
     }
 
     @UiHandler("listBox")

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/MultipleEnumValuePairEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/MultipleEnumValuePairEditor.java
@@ -56,6 +56,7 @@ public class MultipleEnumValuePairEditor
         this.valuePairDefinition = valuePairDefinition;
         view.initItems( createItemList( valuePairDefinition.getClassName(), valuePairDefinition.enumValues() ) );
         view.setValuePairLabel( ValuePairEditorUtil.buildValuePairLabel( valuePairDefinition ) );
+        view.showValuePairRequiredIndicator( !valuePairDefinition.hasDefaultValue() );
     }
 
     private List<Pair<String, String>> createItemList( String className, String[] enumValues ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/MultipleEnumValuePairEditorView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/MultipleEnumValuePairEditorView.java
@@ -18,12 +18,12 @@ package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddom
 
 import java.util.List;
 
-import com.google.gwt.user.client.ui.IsWidget;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.HasErrorMessage;
+import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditorView;
 import org.uberfire.commons.data.Pair;
 
 public interface MultipleEnumValuePairEditorView
-        extends IsWidget,
+        extends ValuePairEditorView,
         HasErrorMessage {
 
     String EMPTY_ARRAY = "_EMPTY_ARRAY_";
@@ -39,7 +39,5 @@ public interface MultipleEnumValuePairEditorView
     void initItems( List<Pair<String, String>> options );
 
     void setSelectedValues( List<String> value );
-
-    void setValuePairLabel( String label );
 
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/MultipleEnumValuePairEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/enums/MultipleEnumValuePairEditorViewImpl.java
@@ -124,6 +124,16 @@ public class MultipleEnumValuePairEditorViewImpl
     }
 
     @Override
+    public void showValuePairName( boolean show ) {
+        valuePairLabel.setVisible( show );
+    }
+
+    @Override
+    public void showValuePairRequiredIndicator( boolean required ) {
+        valuePairLabel.setShowRequiredIndicator( required );
+    }
+
+    @Override
     public void setErrorMessage( String errorMessage ) {
         //TODO implement the error message in case it's needed
     }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/generic/GenericValuePairEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/generic/GenericValuePairEditor.java
@@ -72,6 +72,7 @@ public class GenericValuePairEditor
     public void init( AnnotationValuePairDefinition valuePairDefinition ) {
         this.valuePairDefinition = valuePairDefinition;
         view.setValuePairLabel( ValuePairEditorUtil.buildValuePairLabel( valuePairDefinition ) );
+        view.showValuePairRequiredIndicator( !valuePairDefinition.hasDefaultValue() );
     }
 
     public String getName() {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/generic/GenericValuePairEditorView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/generic/GenericValuePairEditorView.java
@@ -18,9 +18,10 @@ package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddom
 
 import com.google.gwt.user.client.ui.IsWidget;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.HasErrorMessage;
+import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditorView;
 
 public interface GenericValuePairEditorView
-    extends IsWidget,
+    extends ValuePairEditorView,
         HasErrorMessage {
 
     interface Presenter {
@@ -32,8 +33,6 @@ public interface GenericValuePairEditorView
     }
 
     void setPresenter( Presenter presenter );
-
-    void setValuePairLabel( String valuePairName );
 
     void setValue( String text );
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/generic/GenericValuePairEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/generic/GenericValuePairEditorViewImpl.java
@@ -101,6 +101,16 @@ public class GenericValuePairEditorViewImpl
     }
 
     @Override
+    public void showValuePairName( boolean show ) {
+        valuePairLabel.setVisible( show );
+    }
+
+    @Override
+    public void showValuePairRequiredIndicator( boolean required ) {
+        valuePairLabel.setShowRequiredIndicator( required );
+    }
+
+    @Override
     public void setErrorMessage( String errorMessage ) {
         valuePairValueInline.setText( errorMessage );
     }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/multiple/MultipleValuePairEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/multiple/MultipleValuePairEditor.java
@@ -59,6 +59,7 @@ public abstract class MultipleValuePairEditor
         this.valuePairDefinition = valuePairDefinition;
         view.init( valuePairDefinition );
         view.setValuePairLabel( ValuePairEditorUtil.buildValuePairLabel( valuePairDefinition ) );
+        view.showValuePairRequiredIndicator( !valuePairDefinition.hasDefaultValue() );
     }
 
     public List<?> getValue( ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/multiple/MultipleValuePairEditorView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/multiple/MultipleValuePairEditorView.java
@@ -18,13 +18,13 @@ package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddom
 
 import java.util.List;
 
-import com.google.gwt.user.client.ui.IsWidget;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.HasErrorMessage;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditor;
+import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditorView;
 import org.kie.workbench.common.services.datamodeller.core.AnnotationValuePairDefinition;
 
 public interface MultipleValuePairEditorView
-        extends IsWidget,
+        extends ValuePairEditorView,
                 HasErrorMessage {
 
     interface Presenter {
@@ -44,8 +44,6 @@ public interface MultipleValuePairEditorView
     void setPresenter( Presenter presenter );
 
     void init( AnnotationValuePairDefinition valuePairDefinition );
-
-    void setValuePairLabel( String valuePairLabel );
 
     void removeItem( Integer itemId );
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/multiple/MultipleValuePairEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/multiple/MultipleValuePairEditorViewImpl.java
@@ -96,6 +96,16 @@ public class MultipleValuePairEditorViewImpl
     }
 
     @Override
+    public void showValuePairName( boolean show ) {
+        this.valuePairLabel.setVisible( show );
+    }
+
+    @Override
+    public void showValuePairRequiredIndicator( boolean required ) {
+        this.valuePairLabel.setShowRequiredIndicator( required );
+    }
+
+    @Override
     public void setErrorMessage( String errorMessage ) {
     }
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/numeric/NumericValuePairEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/numeric/NumericValuePairEditor.java
@@ -57,6 +57,7 @@ public class NumericValuePairEditor
         this.valuePairDefinition = valuePairDefinition;
         numberType = ValuePairEditorUtil.getNumberType( valuePairDefinition );
         view.setValuePairLabel( ValuePairEditorUtil.buildValuePairLabel( valuePairDefinition ) );
+        view.showValuePairRequiredIndicator( !valuePairDefinition.hasDefaultValue() );
     }
 
     public Object getValue( ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/numeric/NumericValuePairEditorView.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/numeric/NumericValuePairEditorView.java
@@ -16,11 +16,11 @@
 
 package org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.numeric;
 
-import com.google.gwt.user.client.ui.IsWidget;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.HasErrorMessage;
+import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.valuepaireditor.ValuePairEditorView;
 
 public interface NumericValuePairEditorView
-        extends IsWidget,
+        extends ValuePairEditorView,
         HasErrorMessage {
 
     interface Presenter {
@@ -34,10 +34,6 @@ public interface NumericValuePairEditorView
     void setValue( String value );
 
     String getValue( );
-
-    void setValuePairLabel( String valuePairLabel );
-
-    void showValuePairName( boolean show );
 
     void clear();
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/numeric/NumericValuePairEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/numeric/NumericValuePairEditorViewImpl.java
@@ -93,6 +93,11 @@ public class NumericValuePairEditorViewImpl
     }
 
     @Override
+    public void showValuePairRequiredIndicator( boolean required ) {
+        this.valuePairLabel.setShowRequiredIndicator( required );
+    }
+
+    @Override
     public void setErrorMessage( String errorMessage ) {
         helpInline.setText( errorMessage );
     }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/string/StringValuePairEditor.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/string/StringValuePairEditor.java
@@ -51,6 +51,7 @@ public class StringValuePairEditor
     public void init( AnnotationValuePairDefinition valuePairDefinition ) {
         this.valuePairDefinition = valuePairDefinition;
         view.setValuePairLabel( ValuePairEditorUtil.buildValuePairLabel( valuePairDefinition ) );
+        view.showValuePairRequiredIndicator( !valuePairDefinition.hasDefaultValue() );
     }
 
     @Override
@@ -111,7 +112,7 @@ public class StringValuePairEditor
 
     @Override
     public void onValueChanged() {
-        currentValue = view.getValue();
+        currentValue = "".equals( view.getValue() ) ? null : view.getValue();
         if ( editorHandler != null ) {
             editorHandler.onValueChanged();
         }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/string/StringValuePairEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/advanceddomain/valuepaireditor/string/StringValuePairEditorViewImpl.java
@@ -84,6 +84,11 @@ public class StringValuePairEditorViewImpl
     }
 
     @Override
+    public void showValuePairRequiredIndicator( boolean required ) {
+        this.valuePairLabel.setShowRequiredIndicator( required );
+    }
+
+    @Override
     public void clear() {
         textBox.setText( null );
     }


### PR DESCRIPTION
	- CreateAnnotationWizard
		- It was not possible to type the annotation class name for searchinig
		- String value pair editor permits enter null values when the value pair is required
		- Some other fixes on the value pair editors are also included
		- All value pair editors had the "*" required mark even when the value is not required

	- AdvancedAnnotationListEditor
		- Remove annotation didn't work