### PR TITLE
BZ1263118: 'Repository View' doesn't remember the last visited place

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/FolderListingResolver.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/FolderListingResolver.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.screens.explorer.backend.server;
 
+import java.util.List;
+import javax.inject.Inject;
+
 import org.guvnor.common.services.project.model.Package;
 import org.guvnor.common.services.project.model.Project;
 import org.kie.workbench.common.screens.explorer.model.FolderItem;
@@ -24,12 +27,8 @@ import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
 import org.kie.workbench.common.screens.explorer.service.Option;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 
-import javax.inject.Inject;
-import java.util.List;
-import java.util.Set;
-
-import static java.util.Collections.emptyList;
-import static org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceHelper.toFolderItem;
+import static java.util.Collections.*;
+import static org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceHelper.*;
 
 public class FolderListingResolver {
 
@@ -43,49 +42,47 @@ public class FolderListingResolver {
     }
 
     @Inject
-    public FolderListingResolver(KieProjectService projectService) {
+    public FolderListingResolver( KieProjectService projectService ) {
         this.projectService = projectService;
     }
 
-    public FolderListing resolve(final FolderItem selectedItem,
-                                 final Project selectedProject,
-                                 final Package selectedPackage,
-                                 final ExplorerServiceHelper helper,
-                                 final ActiveOptions options) {
-        init(selectedItem, selectedProject, selectedPackage, helper);
-        return getFolderListing(options);
+    public FolderListing resolve( final FolderItem selectedItem,
+                                  final Project selectedProject,
+                                  final Package selectedPackage,
+                                  final ExplorerServiceHelper helper,
+                                  final ActiveOptions options ) {
+        init( selectedItem, selectedProject, selectedPackage, helper );
+        return getFolderListing( options );
     }
 
-    private void init(final FolderItem selectedItem,
-                      final Project selectedProject,
-                      final Package selectedPackage,
-                      final ExplorerServiceHelper helper) {
+    private void init( final FolderItem selectedItem,
+                       final Project selectedProject,
+                       final Package selectedPackage,
+                       final ExplorerServiceHelper helper ) {
         this.selectedItem = selectedItem;
         this.selectedProject = selectedProject;
         this.selectedPackage = selectedPackage;
         this.helper = helper;
     }
 
-    private FolderListing getFolderListing(final ActiveOptions options) {
+    private FolderListing getFolderListing( final ActiveOptions options ) {
         FolderListing result;
-        if (selectedItem == null) {
-            if (options.contains(Option.BUSINESS_CONTENT)) {
-                result = new FolderListing(
-                        toFolderItem(getDefaultPackage()),
-                        helper.getItems(getDefaultPackage()),
-                        getSegments());
+        if ( selectedItem == null ) {
+            if ( options.contains( Option.BUSINESS_CONTENT ) ) {
+                result = new FolderListing( toFolderItem( getDefaultPackage() ),
+                                            helper.getItems( getDefaultPackage() ),
+                                            getSegments() );
             } else {
-                result = helper.getFolderListing(selectedProject.getRootPath());
+                result = helper.getFolderListing( selectedProject.getRootPath() );
             }
         } else {
-            result = helper.getFolderListing(selectedItem);
+            result = helper.getFolderListing( selectedItem );
         }
 
-        if (selectedPackage != null && result == null) {
-            result = new FolderListing(
-                    toFolderItem(selectedPackage),
-                    helper.getItems(selectedPackage),
-                    helper.getPackageSegments(selectedPackage));
+        if ( selectedPackage != null && result == null ) {
+            result = new FolderListing( toFolderItem( selectedPackage ),
+                                        helper.getItems( selectedPackage ),
+                                        helper.getPackageSegments( selectedPackage ) );
         }
 
         return result;
@@ -93,8 +90,8 @@ public class FolderListingResolver {
 
     private org.guvnor.common.services.project.model.Package getDefaultPackage() {
         final Package defaultPackage;
-        if (selectedPackage == null) {
-            defaultPackage = projectService.resolveDefaultPackage(selectedProject);
+        if ( selectedPackage == null ) {
+            defaultPackage = projectService.resolveDefaultPackage( selectedProject );
         } else {
             defaultPackage = selectedPackage;
         }
@@ -102,10 +99,10 @@ public class FolderListingResolver {
     }
 
     private List<FolderItem> getSegments() {
-        if (selectedPackage == null) {
+        if ( selectedPackage == null ) {
             return emptyList();
         } else {
-            return helper.getPackageSegments(selectedPackage);
+            return helper.getPackageSegments( selectedPackage );
         }
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/ActiveContextItems.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/ActiveContextItems.java
@@ -76,6 +76,10 @@ public class ActiveContextItems {
         return activeContent;
     }
 
+    public Set<Repository> getRepositories() {
+        return repositories;
+    }
+
     public void setActiveContent( FolderListing activeContent ) {
         this.activeContent = activeContent;
     }
@@ -102,10 +106,6 @@ public class ActiveContextItems {
 
     public void setRepositories( final Set<Repository> repositories ) {
         this.repositories = repositories;
-    }
-
-    public Set<Repository> getRepositories() {
-        return repositories;
     }
 
     public void flush() {
@@ -208,7 +208,7 @@ public class ActiveContextItems {
     void updateRepository( final String alias,
                            final Map<String, Object> environment ) {
         if ( repositories != null ) {
-            for (Repository repository : repositories) {
+            for ( Repository repository : repositories ) {
                 if ( repository.getAlias().equals( alias ) ) {
                     repository.getEnvironment().clear();
                     repository.getEnvironment().putAll( environment );

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/ActiveContextOptions.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/ActiveContextOptions.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.kie.workbench.common.screens.explorer.client.widgets;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
+
+@ApplicationScoped
+public class ActiveContextOptions {
+
+    private ActiveOptions options = new ActiveOptions();
+
+    public ActiveOptions getOptions() {
+        return options;
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/ViewPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/ViewPresenter.java
@@ -22,17 +22,15 @@ import org.guvnor.common.services.project.context.ProjectContext;
 import org.guvnor.common.services.project.model.Project;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.repositories.Repository;
-import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
 import org.kie.workbench.common.screens.explorer.model.FolderItem;
 import org.kie.workbench.common.screens.explorer.model.FolderListing;
-import org.kie.workbench.common.screens.explorer.service.Option;
 
 /**
  * Base for the different views
  */
 public interface ViewPresenter extends HasVisibility {
 
-    void update( final ActiveOptions options );
+    void update();
 
     void organizationalUnitSelected( final OrganizationalUnit organizationalUnit );
 
@@ -48,10 +46,7 @@ public interface ViewPresenter extends HasVisibility {
 
     void refresh();
 
-    void loadContent( final FolderItem item,
-                      final ActiveOptions options );
-
-    ActiveOptions getActiveOptions();
+    void loadContent( final FolderItem item );
 
     FolderListing getActiveContent();
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewPresenterImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewPresenterImpl.java
@@ -15,14 +15,11 @@
  */
 package org.kie.workbench.common.screens.explorer.client.widgets.business;
 
-import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewPresenter;
 import org.kie.workbench.common.screens.explorer.client.widgets.BranchChangeHandler;
-import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
-import org.kie.workbench.common.screens.explorer.service.Option;
 
 /**
  * Repository, Package, Folder and File explorer
@@ -30,29 +27,12 @@ import org.kie.workbench.common.screens.explorer.service.Option;
 @ApplicationScoped
 public class BusinessViewPresenterImpl extends BaseViewPresenter {
 
-    private ActiveOptions options = new ActiveOptions( Option.BUSINESS_CONTENT, Option.TREE_NAVIGATOR, Option.EXCLUDE_HIDDEN_ITEMS );
-
     protected BusinessViewWidget view;
 
     @Inject
     public BusinessViewPresenterImpl( final BusinessViewWidget view ) {
         super( view );
         this.view = view;
-    }
-
-    @Override
-    protected void setOptions( final ActiveOptions options ) {
-        this.options = new ActiveOptions( options );
-    }
-
-    @Override
-    public ActiveOptions getActiveOptions() {
-        return options;
-    }
-
-    @Override
-    public void addOption( Option option ) {
-        options.add( option );
     }
 
     public void addBranchChangeHandler( BranchChangeHandler branchChangeHandler ) {

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
@@ -146,10 +146,14 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
                             final Project project,
                             final FolderListing folderListing,
                             final Map<FolderItem, List<FolderItem>> siblings ) {
-        explorer.setupHeader( organizationalUnits, organizationalUnit,
-                              repositories, repository,
-                              projects, project );
-        explorer.loadContent( folderListing, siblings );
+        explorer.setupHeader( organizationalUnits,
+                              organizationalUnit,
+                              repositories,
+                              repository,
+                              projects,
+                              project );
+        explorer.loadContent( folderListing,
+                              siblings );
 
         branchSelector.setRepository( repository );
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/BreadcrumbNavigator.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/BreadcrumbNavigator.java
@@ -15,6 +15,7 @@
 
 package org.kie.workbench.common.screens.explorer.client.widgets.navigator;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
@@ -85,13 +86,15 @@ public class BreadcrumbNavigator extends Composite implements Navigator {
     }
 
     @Override
-    public void loadContent( final FolderListing content,
-                             final Map<FolderItem, List<FolderItem>> siblings ) {
-        loadContent( content );
+    public void loadContent( final FolderListing content ) {
+        loadContent( content,
+                     new HashMap<FolderItem, List<FolderItem>>() );
     }
 
     @Override
-    public void loadContent( final FolderListing content ) {
+    @SuppressWarnings("unused")
+    public void loadContent( final FolderListing content,
+                             final Map<FolderItem, List<FolderItem>> siblings ) {
         if ( content != null ) {
             if ( content.equals( activeContent ) ) {
                 return;
@@ -239,7 +242,7 @@ public class BreadcrumbNavigator extends Composite implements Navigator {
 
             final Tooltip lockTooltip = new Tooltip( lock );
             lockTooltip.setTitle( ( lockOwned ) ? ProjectExplorerConstants.INSTANCE.lockOwnedHint() :
-                    ProjectExplorerConstants.INSTANCE.lockHint() + " " + folderItem.getLockedBy() );
+                                          ProjectExplorerConstants.INSTANCE.lockHint() + " " + folderItem.getLockedBy() );
             lockTooltip.setPlacement( Placement.TOP );
             lockTooltip.setShowDelayMs( 1000 );
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/Explorer.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/Explorer.java
@@ -33,7 +33,6 @@ import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.Pull;
 import org.jboss.errai.ioc.client.container.IOC;
-import org.kie.workbench.common.screens.explorer.client.resources.ProjectExplorerResources;
 import org.kie.workbench.common.screens.explorer.client.resources.i18n.ProjectExplorerConstants;
 import org.kie.workbench.common.screens.explorer.client.utils.IdHelper;
 import org.kie.workbench.common.screens.explorer.client.widgets.ViewPresenter;
@@ -252,14 +251,17 @@ public class Explorer extends Composite {
         }
     }
 
-    public void loadContent( FolderListing folderListing ) {
-        this.loadContent( folderListing, null );
+    public void loadContent( FolderListing content ) {
+        if ( content != null ) {
+            activeNavigator.loadContent( content );
+        }
     }
 
     public void loadContent( final FolderListing content,
                              final Map<FolderItem, List<FolderItem>> siblings ) {
         if ( content != null ) {
-            activeNavigator.loadContent( content, siblings );
+            activeNavigator.loadContent( content,
+                                         siblings );
         }
     }
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/Navigator.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/Navigator.java
@@ -38,11 +38,11 @@ public interface Navigator extends IsWidget {
 
     void setPresenter( final ViewPresenter presenter );
 
-    public static interface NavigatorItem {
+    interface NavigatorItem {
 
-        public void addDirectory( final FolderItem child );
+        void addDirectory( final FolderItem child );
 
-        public void addFile( final FolderItem child );
+        void addFile( final FolderItem child );
 
         void cleanup();
     }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewPresenterImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewPresenterImpl.java
@@ -15,14 +15,11 @@
  */
 package org.kie.workbench.common.screens.explorer.client.widgets.technical;
 
-import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.kie.workbench.common.screens.explorer.client.widgets.BaseViewPresenter;
 import org.kie.workbench.common.screens.explorer.client.widgets.BranchChangeHandler;
-import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
-import org.kie.workbench.common.screens.explorer.service.Option;
 
 /**
  * Repository, Package, Folder and File explorer
@@ -30,29 +27,12 @@ import org.kie.workbench.common.screens.explorer.service.Option;
 @ApplicationScoped
 public class TechnicalViewPresenterImpl extends BaseViewPresenter {
 
-    private ActiveOptions options = new ActiveOptions( Option.TECHNICAL_CONTENT, Option.BREADCRUMB_NAVIGATOR, Option.EXCLUDE_HIDDEN_ITEMS );
-
     protected TechnicalViewWidget view;
 
     @Inject
     public TechnicalViewPresenterImpl( final TechnicalViewWidget view ) {
         super( view );
         this.view = view;
-    }
-
-    @Override
-    protected void setOptions( ActiveOptions options ) {
-        this.options = new ActiveOptions( options );
-    }
-
-    @Override
-    public ActiveOptions getActiveOptions() {
-        return options;
-    }
-
-    @Override
-    public void addOption( final Option option ) {
-        options.add( option );
     }
 
     public void addBranchChangeHandler( BranchChangeHandler branchChangeHandler ) {

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.java
@@ -63,11 +63,11 @@ public class TechnicalViewWidget extends BaseViewImpl implements View {
     @UiField
     Explorer explorer;
 
-    @UiField( provided = true )
+    @UiField(provided = true)
     @Inject
     BranchSelector branchSelector;
 
-    @UiField( provided = true )
+    @UiField(provided = true)
     @Inject
     TagSelector tagSelector;
 
@@ -95,7 +95,10 @@ public class TechnicalViewWidget extends BaseViewImpl implements View {
     @Override
     public void init( final ViewPresenter presenter ) {
         this.presenter = presenter;
-        explorer.init( Explorer.Mode.EXPANDED, techOptions, Explorer.NavType.BREADCRUMB, presenter );
+        explorer.init( Explorer.Mode.EXPANDED,
+                       techOptions,
+                       Explorer.NavType.BREADCRUMB,
+                       presenter );
     }
 
     @Override
@@ -107,13 +110,18 @@ public class TechnicalViewWidget extends BaseViewImpl implements View {
                             final Project activeProject,
                             final FolderListing folderListing,
                             final Map<FolderItem, List<FolderItem>> siblings ) {
-        explorer.setupHeader( organizationalUnits, activeOrganizationalUnit,
-                repositories, activeRepository,
-                projects, activeProject );
+        explorer.setupHeader( organizationalUnits,
+                              activeOrganizationalUnit,
+                              repositories,
+                              activeRepository,
+                              projects,
+                              activeProject );
 
-        tagSelector.loadContent( presenter.getActiveContentTags(), presenter.getCurrentTag() );
+        tagSelector.loadContent( presenter.getActiveContentTags(),
+                                 presenter.getCurrentTag() );
 
-        explorer.loadContent( folderListing, siblings );
+        explorer.loadContent( folderListing,
+                              siblings );
 
         branchSelector.setRepository( activeRepository );
 
@@ -126,7 +134,8 @@ public class TechnicalViewWidget extends BaseViewImpl implements View {
 
     @Override
     public void renderItems( FolderListing folderListing ) {
-        tagSelector.loadContent( presenter.getActiveContentTags(), presenter.getCurrentTag() );
+        tagSelector.loadContent( presenter.getActiveContentTags(),
+                                 presenter.getCurrentTag() );
         explorer.loadContent( folderListing );
     }
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1263118

The changes made fall into three categories:

1) When ```TECHNICAL_CONTENT``` is requested in ```ProjectExplorerContentResolver``` re-use the ```lastContent.getLastFolderItem().getItem()``` where applicable (we used to always fall back to ```null``` which forced re-load from the project root).

2) We used to pass ```ActiveOptions``` around all over the place, cloning and overwriting content until our hearts content. This lead to ```ActiveOptions``` state depending on the code-path. IMO, this led to inconsistencies. I've replaced the general munging of different instances with a single ```@ApplicationScoped``` CDI bean holding a single instance of ```ActiveOptions``` shared between all applicable consumers.

3) ```TreeNavigator``` was throwing some ```NPEs``` in Chrome Dev Console which was also leading to subsequent code to not run, which could lead to inconsistent state in the UI (e.g. menu items not being updated correctly). I've added a bunch of defensive programming checks to simply avoid NPEs being logged (smells bad, but since this screen is set for another re-write soon I thought not to waste too much time on it). I didn't experience any change in behaviour when re-trying the ```TreeNavigator```.

