### PR TITLE
DROOLS-933: Allow to optionally pass a dependency filter when creating KieModuleMetaData

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/cache/LRUProjectDataModelOracleCache.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/cache/LRUProjectDataModelOracleCache.java
@@ -24,6 +24,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.drools.compiler.kproject.xml.DependencyFilter;
 import org.drools.core.rule.TypeMetaInfo;
 import org.drools.workbench.models.datamodel.imports.Import;
 import org.drools.workbench.models.datamodel.imports.Imports;
@@ -106,7 +107,8 @@ public class LRUProjectDataModelOracleCache extends LRUCache<KieProject, Project
         final Builder builder = cache.assertBuilder( project );
 
         //Create the ProjectOracle...
-        final KieModuleMetaData kieModuleMetaData = KieModuleMetaData.Factory.newKieModuleMetaData( builder.getKieModuleIgnoringErrors() );
+        final KieModuleMetaData kieModuleMetaData = KieModuleMetaData.Factory.newKieModuleMetaData( builder.getKieModuleIgnoringErrors(),
+                                                                                                    DependencyFilter.COMPILE_FILTER );
         final ProjectDataModelOracleBuilder pdBuilder = ProjectDataModelOracleBuilder.newProjectOracleBuilder();
 
         //Get a "white list" of package names that are available for authoring

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelDependencyExclusionTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelDependencyExclusionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.services.datamodel.backend.server;
+
+import java.net.URL;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
+import org.jboss.weld.environment.se.StartMain;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import static org.junit.Assert.*;
+import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
+
+/**
+ * Tests for DataModelService
+ */
+public class ProjectDataModelDependencyExclusionTest {
+
+    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
+    private BeanManager beanManager;
+    private Paths paths;
+
+    @Before
+    public void setUp() throws Exception {
+        //Bootstrap WELD container
+        StartMain startMain = new StartMain( new String[ 0 ] );
+        beanManager = startMain.go().getBeanManager();
+
+        //Instantiate Paths used in tests for Path conversion
+        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
+        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
+        paths = (Paths) beanManager.getReference( pathsBean,
+                                                  Paths.class,
+                                                  cc );
+
+        //Ensure URLs use the default:// scheme
+        fs.forceAsDefault();
+    }
+
+    @Test
+    public void testBuilderExcludeTestProvidedScopeDependencies() throws Exception {
+        final Bean dataModelServiceBean = (Bean) beanManager.getBeans( DataModelService.class ).iterator().next();
+        final CreationalContext cc = beanManager.createCreationalContext( dataModelServiceBean );
+        final DataModelService dataModelService = (DataModelService) beanManager.getReference( dataModelServiceBean,
+                                                                                               DataModelService.class,
+                                                                                               cc );
+
+        final URL packageUrl = this.getClass().getResource( "/DataModelDependencyExclusionTest1" );
+        final org.uberfire.java.nio.file.Path nioPackagePath = fs.getPath( packageUrl.toURI() );
+        final Path packagePath = paths.convert( nioPackagePath );
+
+        final ProjectDataModelOracle oracle = dataModelService.getProjectDataModel( packagePath );
+
+        assertNotNull( oracle );
+
+        assertEquals( 2,
+                      oracle.getProjectModelFields().size() );
+        assertContains( "t7p1.Bean1",
+                        oracle.getProjectModelFields().keySet() );
+        assertContains( "t7p2.Bean2",
+                        oracle.getProjectModelFields().keySet() );
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.kie.example</groupId>
+  <artifactId>ProjectDataModelPackageWhiteListTest1</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+
+    <!-- Test scoped dependencies should not be in DMO -->
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <version>3.1.4.GA</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Provided scoped dependencies should not be in DMO -->
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <version>2.7.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/java/t7p1/Bean1.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/java/t7p1/Bean1.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package t7p1;
+
+public class Bean1 {
+
+}

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/java/t7p2/Bean2.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/java/t7p2/Bean2.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package t7p2;
+
+public class Bean2 {
+
+}

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/resources/META-INF/kmodule.xml
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+
+</kmodule>

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/resources/empty.rdrl
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/resources/DataModelDependencyExclusionTest1/src/main/resources/empty.rdrl
@@ -1,0 +1,7 @@
+import java.lang.Number;
+
+rule "empty"
+	dialect "mvel"
+	when
+	then
+end

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/Builder.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/Builder.java
@@ -31,6 +31,7 @@ import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
+import org.drools.compiler.kproject.xml.DependencyFilter;
 import org.drools.compiler.kproject.xml.PomModel;
 import org.drools.workbench.models.datamodel.imports.Import;
 import org.drools.workbench.models.datamodel.imports.Imports;
@@ -201,7 +202,8 @@ public class Builder {
             //At the end we are interested to ensure that external .jar files referenced as dependencies don't have
             // referential inconsistencies. We will at least provide a basic algorithm to ensure that if an external class
             // X references another external class Y, Y is also accessible by the class loader.
-            final KieModuleMetaData kieModuleMetaData = KieModuleMetaData.Factory.newKieModuleMetaData( ( (InternalKieBuilder) kieBuilder ).getKieModuleIgnoringErrors() );
+            final KieModuleMetaData kieModuleMetaData = KieModuleMetaData.Factory.newKieModuleMetaData( ( (InternalKieBuilder) kieBuilder ).getKieModuleIgnoringErrors(),
+                                                                                                        DependencyFilter.COMPILE_FILTER );
             final Set<String> packageNamesWhiteList = packageNameWhiteList.filterPackageNames( project,
                                                                                                kieModuleMetaData.getPackages() );
             //store the project dependencies ClassLoader for optimization purposes.


### PR DESCRIPTION
The captioned JIRA changed behaviour of ```KieModuleMetaData.Factory.newKieModuleMetaData()``` to include *test* scoped dependencies by default. This commit rectifies that - and also excludes *provided* scope dependencies too which used to cause ```ClassNotFoundException``` type exceptions that we trapped and reported.