### PR TITLE
JBPM-4777: +Responsive design fix for data modeller after BS3 upgrade

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenViewImpl.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenViewImpl.ui.xml
@@ -28,15 +28,23 @@
             padding-top: 20px;
             padding-bottom: 20px;
         }
+        
+        .dataObjectPanel {
+            min-width: 200px;            
+        }
+        
+        .domainContainerPanel {
+            min-width: 285px;            
+        }
 
     </ui:style>
 
     <b:Container fluid="true">
         <b:Row addStyleNames="{style.container}">
-            <b:Column size="MD_6">
+            <b:Column size="MD_6" addStyleNames="{style.dataObjectPanel}">
                 <gwt:FlowPanel ui:field="dataObjectPanel" />
             </b:Column>
-            <b:Column size="MD_6">
+            <b:Column size="MD_6" addStyleNames="{style.domainContainerPanel}">
                 <b:Legend ui:field="domainContainerTitle"/>
                 <gwt:FlowPanel ui:field="domainContainerPanel"/>
             </b:Column>


### PR DESCRIPTION
This is a responsive design improvement for data modeller on master (after BS3 upgrade and docks resizing) (not needed on 6.3.x).

It makes sure the data modeller renders fine in case of minimal horizontal space. The domain container panel is then placed underneath the data object panel and remains usable.

Before: (https://dl.dropboxusercontent.com/u/16288770/before.png)
After: (https://dl.dropboxusercontent.com/u/16288770/after.png)
