### PR TITLE
BZ1275325: WAS: indexing fails with ContextNotActiveException

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerWBControllerAdminImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerWBControllerAdminImpl.java
@@ -15,7 +15,6 @@
 
 package org.kie.workbench.common.screens.server.management.backend;
 
-import java.util.concurrent.Executor;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -23,12 +22,13 @@ import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.controller.api.model.KieServerInstance;
 import org.kie.server.controller.api.storage.KieServerControllerStorage;
 import org.kie.server.controller.rest.RestKieServerControllerAdminImpl;
+import org.uberfire.commons.async.DisposableExecutor;
 import org.uberfire.commons.async.SimpleAsyncExecutorService;
 
 @ApplicationScoped
 public class KieServerWBControllerAdminImpl extends RestKieServerControllerAdminImpl {
 
-    private SimpleAsyncExecutorService executor;
+    private DisposableExecutor executor;
 
     public KieServerWBControllerAdminImpl() {
         this.executor = SimpleAsyncExecutorService.getDefaultInstance();

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/ServerManagementServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/ServerManagementServiceImpl.java
@@ -68,6 +68,7 @@ import org.kie.workbench.common.screens.server.management.service.ServerAlreadyR
 import org.kie.workbench.common.screens.server.management.service.ServerManagementService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.commons.async.DisposableExecutor;
 import org.uberfire.commons.async.SimpleAsyncExecutorService;
 
 import static org.uberfire.commons.validation.PortablePreconditions.*;
@@ -92,7 +93,7 @@ public class ServerManagementServiceImpl implements ServerManagementService {
     private ServerReferenceStorageImpl storage;
     private RemoteAccessImpl remoteAccess;
 
-    private SimpleAsyncExecutorService executor;
+    private DisposableExecutor executor;
 
     private KieServerControllerAdmin controllerAdmin;
     private KieServerControllerStorage controllerStorage;
@@ -147,7 +148,7 @@ public class ServerManagementServiceImpl implements ServerManagementService {
                                         final RemoteAccessImpl remoteAccess,
                                         final KieServerControllerAdmin controllerAdmin,
                                         final KieServerControllerStorage controllerStorage,
-                                        final SimpleAsyncExecutorService executor ) {
+                                        final DisposableExecutor executor ) {
         this.serverConnectedEvent = serverConnectedEvent;
         this.serverOnErrorEvent = serverOnErrorEvent;
         this.serverDeletedEvent = serverDeletedEvent;

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/ServerManagementServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/ServerManagementServiceImplTest.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.Executor;
 
 import org.guvnor.common.services.project.model.GAV;
 import org.junit.Before;
@@ -54,6 +53,7 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.uberfire.commons.async.DisposableExecutor;
 import org.uberfire.commons.async.SimpleAsyncExecutorService;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -107,7 +107,7 @@ public class ServerManagementServiceImplTest {
     @Mock
     private KieServerControllerStorage controllerStorage;
 
-    private SimpleAsyncExecutorService executor = SimpleAsyncExecutorService.getDefaultInstance();
+    private DisposableExecutor executor = SimpleAsyncExecutorService.getDefaultInstance();
 
     private ServerManagementServiceImpl serverManagementService;
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1275325

Implementation of EJB was flawed; it was neither an "no interface" bean, nor a "local interface" bean.