### PR TITLE
BZ1193484: Roles added to Projects are ignored by Business Central. Fix injection of ProjectService

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/pom.xml
@@ -101,6 +101,11 @@
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-project-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-services-api</artifactId>
+    </dependency>
     
     <!-- Errai Core -->
     <dependency>

--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/java/org/kie/workbench/common/screens/social/hp/security/SocialEventProjectConstraint.java
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/java/org/kie/workbench/common/screens/social/hp/security/SocialEventProjectConstraint.java
@@ -24,6 +24,7 @@ import org.guvnor.common.services.project.social.ProjectEventType;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.service.SocialSecurityConstraint;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.uberfire.commons.validation.PortablePreconditions;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.Paths;
@@ -42,7 +43,7 @@ public class SocialEventProjectConstraint implements SocialSecurityConstraint {
 
     private SocialEventRepositoryConstraint delegate;
     private AuthorizationManager authorizationManager;
-    private ProjectService projectService;
+    private KieProjectService projectService;
     private User identity;
 
     public SocialEventProjectConstraint() {
@@ -52,7 +53,7 @@ public class SocialEventProjectConstraint implements SocialSecurityConstraint {
     @Inject
     public SocialEventProjectConstraint( final SocialEventRepositoryConstraint delegate,
                                          final AuthorizationManager authorizationManager,
-                                         final ProjectService projectService,
+                                         final KieProjectService projectService,
                                          final User identity ) {
         this.delegate = PortablePreconditions.checkNotNull( "delegate",
                                                             delegate );

--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/test/org/kie/workbench/common/screens/social/hp/security/SocialEventProjectConstraintTest.java
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/test/org/kie/workbench/common/screens/social/hp/security/SocialEventProjectConstraintTest.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Date;
 
 import org.guvnor.common.services.project.model.Project;
-import org.guvnor.common.services.project.service.ProjectService;
 import org.guvnor.structure.backend.repositories.RepositoryServiceImpl;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
@@ -34,6 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.model.SocialUser;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.security.authz.AuthorizationManager;
@@ -54,7 +54,7 @@ public class SocialEventProjectConstraintTest {
     private RepositoryServiceImpl repositoryService;
 
     @Mock
-    private ProjectService projectService;
+    private KieProjectService projectService;
 
     @Mock
     private User identity;


### PR DESCRIPTION
Injection of ```ProjectService``` failed at runtime. I changed to ```ProjectService<?>``` which worked OK locally on Wildfly however have elected to use the concrete interface ```KieProjectService``` to avoid any potential (unforeseen) issues on WebSphere.