### PR TITLE
GUVNOR-2293: Support by-passing NewResourceView from NewResourceHandler

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewProjectHandlerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewProjectHandlerTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.handlers;
+
+import com.google.gwt.core.client.Callback;
+import org.guvnor.asset.management.model.RepositoryStructureModel;
+import org.guvnor.asset.management.service.RepositoryStructureService;
+import org.guvnor.common.services.project.context.ProjectContext;
+import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.model.POM;
+import org.guvnor.structure.repositories.Repository;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.screens.projecteditor.client.wizard.NewProjectWizard;
+import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
+import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mvp.Command;
+import org.uberfire.workbench.type.AnyResourceTypeDefinition;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class NewProjectHandlerTest {
+
+    private NewProjectHandler handler;
+
+    private ProjectContext context;
+    private NewProjectWizard wizard;
+    private RepositoryStructureService repoStructureService;
+    private CallerMock<RepositoryStructureService> repoStructureCaller;
+
+    private AnyResourceTypeDefinition resourceType = mock( AnyResourceTypeDefinition.class );
+    private NewResourcePresenter newResourcePresenter = mock( NewResourcePresenter.class );
+
+    @Before
+    public void setup() {
+        context = mock( ProjectContext.class );
+        wizard = mock( NewProjectWizard.class );
+        repoStructureService = mock( RepositoryStructureService.class );
+        repoStructureCaller = new CallerMock<RepositoryStructureService>( repoStructureService );
+        handler = new NewProjectHandler( context,
+                                         wizard,
+                                         repoStructureCaller,
+                                         resourceType );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCreate() {
+        handler.create( mock( org.guvnor.common.services.project.model.Package.class ),
+                        "projectName",
+                        newResourcePresenter );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testValidate() {
+        handler.validate( "projectName",
+                          mock( ValidatorWithReasonCallback.class ) );
+    }
+
+    @Test
+    public void testAcceptContextNoActiveRepository() {
+        when( context.getActiveRepository() ).thenReturn( null );
+
+        final Callback<Boolean, Void> callback = mock( Callback.class );
+        handler.acceptContext( context,
+                               callback );
+
+        verify( callback,
+                times( 1 ) ).onSuccess( eq( false ) );
+    }
+
+    @Test
+    public void testAcceptContextWithUnmanagedActiveRepository() {
+        final Repository repository = mock( Repository.class );
+        final RepositoryStructureModel model = mock( RepositoryStructureModel.class );
+        when( context.getActiveRepository() ).thenReturn( repository );
+        when( repoStructureService.load( any( Repository.class ) ) ).thenReturn( model );
+        when( model.isManaged() ).thenReturn( false );
+
+        final Callback<Boolean, Void> callback = mock( Callback.class );
+        handler.acceptContext( context,
+                               callback );
+
+        verify( callback,
+                times( 1 ) ).onSuccess( eq( true ) );
+    }
+
+    @Test
+    public void testAcceptContextWithManagedActiveRepositoryIsMultiModule() {
+        final Repository repository = mock( Repository.class );
+        final RepositoryStructureModel model = mock( RepositoryStructureModel.class );
+        when( context.getActiveRepository() ).thenReturn( repository );
+        when( repoStructureService.load( any( Repository.class ) ) ).thenReturn( model );
+        when( model.isManaged() ).thenReturn( true );
+        when( model.isMultiModule() ).thenReturn( true );
+
+        final Callback<Boolean, Void> callback = mock( Callback.class );
+        handler.acceptContext( context,
+                               callback );
+
+        verify( callback,
+                times( 1 ) ).onSuccess( eq( true ) );
+    }
+
+    @Test
+    public void testAcceptContextWithManagedActiveRepositoryIsNotMultiModule() {
+        final Repository repository = mock( Repository.class );
+        final RepositoryStructureModel model = mock( RepositoryStructureModel.class );
+        when( context.getActiveRepository() ).thenReturn( repository );
+        when( repoStructureService.load( any( Repository.class ) ) ).thenReturn( model );
+        when( model.isManaged() ).thenReturn( true );
+        when( model.isMultiModule() ).thenReturn( false );
+
+        final Callback<Boolean, Void> callback = mock( Callback.class );
+        handler.acceptContext( context,
+                               callback );
+
+        verify( callback,
+                times( 1 ) ).onSuccess( eq( false ) );
+    }
+
+    @Test
+    public void testGetCommandWithUnmanagedActiveRepository() {
+        final Repository repository = mock( Repository.class );
+        final RepositoryStructureModel model = mock( RepositoryStructureModel.class );
+        when( context.getActiveRepository() ).thenReturn( repository );
+        when( repoStructureService.load( any( Repository.class ) ) ).thenReturn( model );
+        when( model.isManaged() ).thenReturn( false );
+
+        final Command command = handler.getCommand( newResourcePresenter );
+        assertNotNull( command );
+
+        command.execute();
+
+        verify( wizard,
+                times( 1 ) ).setContent( eq( "" ) );
+        verify( wizard,
+                times( 1 ) ).start();
+    }
+
+    @Test
+    public void testGetCommandWithManagedActiveRepository() {
+        final Repository repository = mock( Repository.class );
+        final RepositoryStructureModel model = mock( RepositoryStructureModel.class );
+        when( context.getActiveRepository() ).thenReturn( repository );
+        when( repoStructureService.load( any( Repository.class ) ) ).thenReturn( model );
+        when( model.isManaged() ).thenReturn( true );
+
+        final POM pom = new POM( new GAV( "groupID",
+                                          "artifactID",
+                                          "version" ) );
+        when( model.getPOM() ).thenReturn( pom );
+
+        final Command command = handler.getCommand( newResourcePresenter );
+        assertNotNull( command );
+
+        command.execute();
+
+        verify( wizard,
+                times( 1 ) ).setContent( eq( "" ),
+                                         eq( "groupID" ),
+                                         eq( "version" ) );
+        verify( wizard,
+                times( 1 ) ).start();
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/wizard/GAVWizardPageTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/wizard/GAVWizardPageTest.java
@@ -16,18 +16,15 @@
 
 package org.kie.workbench.common.screens.projecteditor.client.wizard;
 
-import java.lang.annotation.Annotation;
-import javax.enterprise.event.Event;
-
 import org.guvnor.common.services.project.client.POMEditorPanel;
 import org.guvnor.common.services.project.model.POM;
-import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
-import org.jboss.errai.common.client.api.RemoteCallback;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.screens.projecteditor.service.ProjectScreenService;
+import org.kie.workbench.common.services.shared.validation.ValidationService;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
 
 import static org.mockito.Mockito.*;
 
@@ -37,15 +34,132 @@ public class GAVWizardPageTest {
     private GAVWizardPage page;
     private GAVWizardPageView view;
 
+    private ProjectScreenService projectScreenService;
+    private ValidationService validationService;
+
     @Before
     public void setUp() throws Exception {
+        projectScreenService = mock( ProjectScreenService.class );
+        validationService = mock( ValidationService.class );
         pomEditor = mock( POMEditorPanel.class );
         view = mock( GAVWizardPageView.class );
-        page = new GAVWizardPage(
-                pomEditor,
-                view,
-                new WizardPageStatusChangeEventMock(),
-                new ProjectScreenServiceMock() );
+        page = spy( new GAVWizardPage( pomEditor,
+                                       view,
+                                       new EventSourceMock<WizardPageStatusChangeEvent>(),
+                                       new CallerMock<ProjectScreenService>( projectScreenService ),
+                                       new CallerMock<ValidationService>( validationService ) ) );
+    }
+
+    @Test
+    public void testInvalidPOMWithParent() throws Exception {
+        when( projectScreenService.validateGroupId( any( String.class ) ) ).thenReturn( false );
+        when( projectScreenService.validateArtifactId( any( String.class ) ) ).thenReturn( false );
+        when( projectScreenService.validateVersion( any( String.class ) ) ).thenReturn( false );
+        when( validationService.isProjectNameValid( any( String.class ) ) ).thenReturn( false );
+        page.setPom( new POM(),
+                     true );
+
+        verify( page,
+                times( 1 ) ).validateName( any( String.class ) );
+        verify( page,
+                never() ).validateGroupId( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateArtifactId( any( String.class ) );
+        verify( page,
+                never() ).validateVersion( any( String.class ) );
+
+        verify( pomEditor,
+                times( 1 ) ).setValidName( eq( false ) );
+        verify( pomEditor,
+                never() ).setValidGroupID( eq( false ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidArtifactID( eq( false ) );
+        verify( pomEditor,
+                never() ).setValidVersion( eq( false ) );
+    }
+
+    @Test
+    public void testInvalidPOMWithoutParent() throws Exception {
+        when( projectScreenService.validateGroupId( any( String.class ) ) ).thenReturn( false );
+        when( projectScreenService.validateArtifactId( any( String.class ) ) ).thenReturn( false );
+        when( projectScreenService.validateVersion( any( String.class ) ) ).thenReturn( false );
+        when( validationService.isProjectNameValid( any( String.class ) ) ).thenReturn( false );
+        page.setPom( new POM(),
+                     false );
+
+        verify( page,
+                times( 1 ) ).validateName( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateGroupId( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateArtifactId( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateVersion( any( String.class ) );
+
+        verify( pomEditor,
+                times( 1 ) ).setValidName( eq( false ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidGroupID( eq( false ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidArtifactID( eq( false ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidVersion( eq( false ) );
+    }
+
+    @Test
+    public void testValidPOMWithParent() throws Exception {
+        when( projectScreenService.validateGroupId( any( String.class ) ) ).thenReturn( true );
+        when( projectScreenService.validateArtifactId( any( String.class ) ) ).thenReturn( true );
+        when( projectScreenService.validateVersion( any( String.class ) ) ).thenReturn( true );
+        when( validationService.isProjectNameValid( any( String.class ) ) ).thenReturn( true );
+        page.setPom( new POM(),
+                     true );
+
+        verify( page,
+                times( 1 ) ).validateName( any( String.class ) );
+        verify( page,
+                never() ).validateGroupId( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateArtifactId( any( String.class ) );
+        verify( page,
+                never() ).validateVersion( any( String.class ) );
+
+        verify( pomEditor,
+                times( 1 ) ).setValidName( eq( true ) );
+        verify( pomEditor,
+                never() ).setValidGroupID( eq( true ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidArtifactID( eq( true ) );
+        verify( pomEditor,
+                never() ).setValidVersion( eq( true ) );
+    }
+
+    @Test
+    public void testValidPOMWithoutParent() throws Exception {
+        when( projectScreenService.validateGroupId( any( String.class ) ) ).thenReturn( true );
+        when( projectScreenService.validateArtifactId( any( String.class ) ) ).thenReturn( true );
+        when( projectScreenService.validateVersion( any( String.class ) ) ).thenReturn( true );
+        when( validationService.isProjectNameValid( any( String.class ) ) ).thenReturn( true );
+        page.setPom( new POM(),
+                     false );
+
+        verify( page,
+                times( 1 ) ).validateName( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateGroupId( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateArtifactId( any( String.class ) );
+        verify( page,
+                times( 1 ) ).validateVersion( any( String.class ) );
+
+        verify( pomEditor,
+                times( 1 ) ).setValidName( eq( true ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidGroupID( eq( true ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidArtifactID( eq( true ) );
+        verify( pomEditor,
+                times( 1 ) ).setValidVersion( eq( true ) );
     }
 
     @Test
@@ -67,44 +181,4 @@ public class GAVWizardPageTest {
         verify( pomEditor ).disableVersion( "InheritedFromAParentPOM" );
     }
 
-    private class WizardPageStatusChangeEventMock
-            implements Event<WizardPageStatusChangeEvent> {
-
-        @Override
-        public void fire( WizardPageStatusChangeEvent wizardPageStatusChangeEvent ) {
-
-        }
-
-        @Override
-        public Event<WizardPageStatusChangeEvent> select( Annotation... annotations ) {
-            return null;
-        }
-
-        @Override
-        public <U extends WizardPageStatusChangeEvent> Event<U> select( Class<U> uClass,
-                                                                        Annotation... annotations ) {
-            return null;
-        }
-
-    }
-
-    private class ProjectScreenServiceMock
-            implements Caller<ProjectScreenService> {
-
-        @Override
-        public ProjectScreenService call() {
-            return mock( ProjectScreenService.class );
-        }
-
-        @Override
-        public ProjectScreenService call( RemoteCallback<?> remoteCallback ) {
-            return mock( ProjectScreenService.class );
-        }
-
-        @Override
-        public ProjectScreenService call( RemoteCallback<?> remoteCallback,
-                                          ErrorCallback<?> errorCallback ) {
-            return mock( ProjectScreenService.class );
-        }
-    }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
@@ -212,6 +212,24 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/DefaultNewResourceHandler.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/DefaultNewResourceHandler.java
@@ -36,6 +36,7 @@ import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
 import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
 import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
+import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
@@ -69,6 +70,29 @@ public abstract class DefaultNewResourceHandler implements NewResourceHandler,
 
     @Inject
     private BusyIndicatorView busyIndicatorView;
+
+    //Package-protected constructor for tests. In an ideal world we'd move to Constructor injection
+    //however that would require every sub-class of this abstract class to also have Constructor
+    //injection.. and that's a lot of refactoring just to be able to test.
+    DefaultNewResourceHandler( final PackageListBox packagesListBox,
+                               final ProjectContext context,
+                               final Caller<KieProjectService> projectService,
+                               final Caller<ValidationService> validationService,
+                               final PlaceManager placeManager,
+                               final Event<NotificationEvent> notificationEvent,
+                               final BusyIndicatorView busyIndicatorView ) {
+        this.packagesListBox = packagesListBox;
+        this.context = context;
+        this.projectService = projectService;
+        this.validationService = validationService;
+        this.placeManager = placeManager;
+        this.notificationEvent = notificationEvent;
+        this.busyIndicatorView = busyIndicatorView;
+    }
+
+    public DefaultNewResourceHandler() {
+        //Zero argument constructor for CDI proxies
+    }
 
     @PostConstruct
     private void setupExtensions() {
@@ -115,6 +139,16 @@ public abstract class DefaultNewResourceHandler implements NewResourceHandler,
         } else {
             callback.onSuccess( context.getActiveProject() != null );
         }
+    }
+
+    @Override
+    public Command getCommand( final NewResourcePresenter newResourcePresenter ) {
+        return new Command() {
+            @Override
+            public void execute() {
+                newResourcePresenter.show( DefaultNewResourceHandler.this );
+            }
+        };
     }
 
     @Override

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceHandler.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceHandler.java
@@ -23,6 +23,7 @@ import org.guvnor.common.services.project.context.ProjectContext;
 import org.guvnor.common.services.project.model.Package;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
+import org.uberfire.mvp.Command;
 import org.uberfire.workbench.type.ResourceTypeDefinition;
 
 /**
@@ -79,4 +80,13 @@ public interface NewResourceHandler {
      */
     void acceptContext( final ProjectContext context,
                         final Callback<Boolean, Void> callback );
+
+    /**
+     * A command to execute instead of defaulting to the NewResourceView.
+     * If this returns null the NewResourceView is shown by default.
+     * @param newResourcePresenter
+     * @return
+     */
+    Command getCommand( final NewResourcePresenter newResourcePresenter );
+
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceView.java
@@ -65,7 +65,7 @@ public class NewResourceView extends BaseModal implements NewResourcePresenter.V
     };
 
     private final ModalFooterOKCancelButtons footer = new ModalFooterOKCancelButtons( okCommand,
-            cancelCommand );
+                                                                                      cancelCommand );
 
     @UiField
     FormGroup fileNameGroup;
@@ -132,26 +132,26 @@ public class NewResourceView extends BaseModal implements NewResourcePresenter.V
 
         //Specialized validation
         presenter.validate( fileName,
-                new ValidatorWithReasonCallback() {
+                            new ValidatorWithReasonCallback() {
 
-                    @Override
-                    public void onSuccess() {
-                        fileNameGroup.setValidationState( ValidationState.NONE );
-                        presenter.makeItem( fileName );
-                    }
+                                @Override
+                                public void onSuccess() {
+                                    fileNameGroup.setValidationState( ValidationState.NONE );
+                                    presenter.makeItem( fileName );
+                                }
 
-                    @Override
-                    public void onFailure() {
-                        fileNameGroup.setValidationState( ValidationState.ERROR );
-                    }
+                                @Override
+                                public void onFailure() {
+                                    fileNameGroup.setValidationState( ValidationState.ERROR );
+                                }
 
-                    @Override
-                    public void onFailure( final String reason ) {
-                        fileNameGroup.setValidationState( ValidationState.ERROR );
-                        fileNameHelpInline.setText( reason );
-                    }
+                                @Override
+                                public void onFailure( final String reason ) {
+                                    fileNameGroup.setValidationState( ValidationState.ERROR );
+                                    fileNameHelpInline.setText( reason );
+                                }
 
-                } );
+                            } );
     }
 
     @Override

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenu.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenu.java
@@ -42,15 +42,23 @@ import org.uberfire.workbench.model.menu.MenuItem;
 @ApplicationScoped
 public class NewResourcesMenu {
 
-    @Inject
     private SyncBeanManager iocBeanManager;
-
-    @Inject
     private NewResourcePresenter newResourcePresenter;
 
     private final List<MenuItem> items = new ArrayList<MenuItem>();
     private boolean hasProjectMenuItem = false;
     private final Map<NewResourceHandler, MenuItem> newResourceHandlers = new HashMap<NewResourceHandler, MenuItem>();
+
+    public NewResourcesMenu() {
+        //Zero argument constructor for CDI proxies
+    }
+
+    @Inject
+    public NewResourcesMenu( final SyncBeanManager iocBeanManager,
+                             final NewResourcePresenter newResourcePresenter ) {
+        this.iocBeanManager = iocBeanManager;
+        this.newResourcePresenter = newResourcePresenter;
+    }
 
     @PostConstruct
     public void setup() {
@@ -65,7 +73,8 @@ public class NewResourcesMenu {
                 final MenuItem menuItem = MenuFactory.newSimpleItem( description ).respondsWith( new Command() {
                     @Override
                     public void execute() {
-                        newResourcePresenter.show( activeHandler );
+                        final Command command = activeHandler.getCommand( newResourcePresenter );
+                        command.execute();
                     }
                 } ).endMenu().build().getItems().get( 0 );
                 newResourceHandlers.put( activeHandler,
@@ -100,7 +109,8 @@ public class NewResourcesMenu {
 
     public List<MenuItem> getMenuItemsWithoutProject() {
         if ( hasProjectMenuItem ) {
-            return items.subList( 1, items.size() );
+            return items.subList( 1,
+                                  items.size() );
         } else {
             return items;
         }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/DefaultNewResourceHandlerTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/DefaultNewResourceHandlerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.handlers;
+
+import javax.enterprise.event.Event;
+
+import com.google.gwt.core.client.Callback;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.context.ProjectContext;
+import org.guvnor.common.services.project.model.Package;
+import org.guvnor.common.services.project.model.Project;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.kie.workbench.common.services.shared.validation.ValidationService;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
+import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.Command;
+import org.uberfire.workbench.events.NotificationEvent;
+import org.uberfire.workbench.type.ResourceTypeDefinition;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DefaultNewResourceHandlerTest {
+
+    private DefaultNewResourceHandler handler;
+
+    private PackageListBox packagesListBox;
+    private ProjectContext context;
+    private KieProjectService projectService;
+    private Caller<KieProjectService> projectServiceCaller;
+    private ValidationService validationService;
+    private Caller<ValidationService> validationServiceCaller;
+    private PlaceManager placeManager;
+    private Event<NotificationEvent> notificationEvent;
+    private BusyIndicatorView busyIndicatorView;
+
+    @Before
+    public void setup() {
+        packagesListBox = mock( PackageListBox.class );
+        context = mock( ProjectContext.class );
+        projectService = mock( KieProjectService.class );
+        projectServiceCaller = new CallerMock<KieProjectService>( projectService );
+        validationService = mock( ValidationService.class );
+        validationServiceCaller = new CallerMock<ValidationService>( validationService );
+        placeManager = mock( PlaceManager.class );
+        notificationEvent = new EventSourceMock<NotificationEvent>();
+        busyIndicatorView = mock( BusyIndicatorView.class );
+
+        handler = new DefaultNewResourceHandler( packagesListBox,
+                                                 context,
+                                                 projectServiceCaller,
+                                                 validationServiceCaller,
+                                                 placeManager,
+                                                 notificationEvent,
+                                                 busyIndicatorView ) {
+            @Override
+            public String getDescription() {
+                return "mock";
+            }
+
+            @Override
+            public IsWidget getIcon() {
+                return null;
+            }
+
+            @Override
+            public ResourceTypeDefinition getResourceType() {
+                final ResourceTypeDefinition resourceType = mock( ResourceTypeDefinition.class );
+                when( resourceType.getPrefix() ).thenReturn( "" );
+                when( resourceType.getSuffix() ).thenReturn( "suffix" );
+                return resourceType;
+            }
+
+            @Override
+            public void create( final org.guvnor.common.services.project.model.Package pkg,
+                                final String baseFileName,
+                                final NewResourcePresenter presenter ) {
+
+            }
+        };
+    }
+
+    @Test
+    public void testValidateValidFileName() {
+        final org.guvnor.common.services.project.model.Package pkg = mock( Package.class );
+        final ValidatorWithReasonCallback callback = mock( ValidatorWithReasonCallback.class );
+        when( packagesListBox.getSelectedPackage() ).thenReturn( pkg );
+        when( validationService.isFileNameValid( "filename.suffix" ) ).thenReturn( true );
+
+        handler.validate( "filename",
+                          callback );
+
+        verify( callback,
+                times( 1 ) ).onSuccess();
+        verify( callback,
+                never() ).onFailure();
+        verify( callback,
+                never() ).onFailure( any( String.class ) );
+    }
+
+    @Test
+    public void testValidateInvalidFileName() {
+        final org.guvnor.common.services.project.model.Package pkg = mock( Package.class );
+        final ValidatorWithReasonCallback callback = mock( ValidatorWithReasonCallback.class );
+        when( packagesListBox.getSelectedPackage() ).thenReturn( pkg );
+        when( validationService.isFileNameValid( "filename.suffix" ) ).thenReturn( false );
+
+        handler.validate( "filename",
+                          callback );
+
+        verify( callback,
+                times( 1 ) ).onFailure( any( String.class ) );
+        verify( callback,
+                never() ).onFailure();
+        verify( callback,
+                never() ).onSuccess();
+    }
+
+    @Test
+    public void testAcceptContextWithNoContext() {
+        final Callback<Boolean, Void> callback = mock( Callback.class );
+
+        handler.acceptContext( null,
+                               callback );
+
+        verify( callback,
+                times( 1 ) ).onSuccess( false );
+    }
+
+    @Test
+    public void testAcceptContextWithContextWithNoProject() {
+        final Callback<Boolean, Void> callback = mock( Callback.class );
+        when( context.getActiveProject() ).thenReturn( null );
+
+        handler.acceptContext( context,
+                               callback );
+        verify( callback,
+                times( 1 ) ).onSuccess( false );
+    }
+
+    @Test
+    public void testAcceptContextWithContextWithProject() {
+        final Callback<Boolean, Void> callback = mock( Callback.class );
+        when( context.getActiveProject() ).thenReturn( mock( Project.class ) );
+
+        handler.acceptContext( context,
+                               callback );
+        verify( callback,
+                times( 1 ) ).onSuccess( true );
+    }
+
+    @Test
+    public void testGetCommand() {
+        final NewResourcePresenter presenter = mock( NewResourcePresenter.class );
+        final Command command = handler.getCommand( presenter );
+        assertNotNull( command );
+
+        command.execute();
+        verify( presenter,
+                times( 1 ) ).show( handler );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenuTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenuTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwt.core.client.Callback;
+import org.guvnor.common.services.project.context.ProjectContext;
+import org.guvnor.common.services.project.context.ProjectContextChangeEvent;
+import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.uberfire.mvp.Command;
+import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.MenuItemCommand;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NewResourcesMenuTest {
+
+    private NewResourcesMenu menu;
+
+    private SyncBeanManager iocBeanManager;
+    private NewResourcePresenter newResourcePresenter;
+    private IOCBeanDef<NewResourceHandler> handlerBeanDef;
+    private NewResourceHandler handler;
+    private Command command;
+
+    @Before
+    public void setup() {
+        iocBeanManager = mock( SyncBeanManager.class );
+        newResourcePresenter = mock( NewResourcePresenter.class );
+        command = mock( Command.class );
+        handlerBeanDef = mock( IOCBeanDef.class );
+        handler = mock( NewResourceHandler.class );
+
+        when( iocBeanManager.lookupBeans( NewResourceHandler.class ) ).thenReturn( new ArrayList<IOCBeanDef<NewResourceHandler>>() {{
+            add( handlerBeanDef );
+        }} );
+        when( handlerBeanDef.getInstance() ).thenReturn( handler );
+        when( handler.getDescription() ).thenReturn( "handler" );
+        when( handler.getCommand( newResourcePresenter ) ).thenReturn( command );
+
+        menu = new NewResourcesMenu( iocBeanManager,
+                                     newResourcePresenter );
+
+        menu.setup();
+    }
+
+    @Test
+    public void testGetMenuItems() {
+        final List<MenuItem> menus = menu.getMenuItems();
+        assertNotNull( menus );
+        assertEquals( 1,
+                      menus.size() );
+    }
+
+    @Test
+    public void testMenuItemCommand() {
+        final List<MenuItem> menus = menu.getMenuItems();
+        assertNotNull( menus );
+        assertEquals( 1,
+                      menus.size() );
+
+        final MenuItem mi = menus.get( 0 );
+        assertTrue( mi.isEnabled() );
+
+        assertTrue( mi instanceof MenuItemCommand );
+        final MenuItemCommand miu = (MenuItemCommand) mi;
+
+        assertNotNull( miu.getCommand() );
+        miu.getCommand().execute();
+
+        verify( command,
+                times( 1 ) ).execute();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnProjectContextChangedEnabled() {
+        final ProjectContextChangeEvent event = mock( ProjectContextChangeEvent.class );
+
+        doAnswer( new Answer() {
+            public Object answer( final InvocationOnMock invocation ) {
+                final Object[] args = invocation.getArguments();
+                final Callback callback = (Callback) args[ 1 ];
+                callback.onSuccess( true );
+                return null;
+            }
+        } ).when( handler ).acceptContext( any( ProjectContext.class ),
+                                           any( Callback.class ) );
+
+        menu.onProjectContextChanged( event );
+
+        final List<MenuItem> menus = menu.getMenuItems();
+        final MenuItem mi = menus.get( 0 );
+        assertTrue( mi.isEnabled() );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnProjectContextChangedDisabled() {
+        final ProjectContextChangeEvent event = mock( ProjectContextChangeEvent.class );
+
+        doAnswer( new Answer() {
+            public Object answer( final InvocationOnMock invocation ) {
+                final Object[] args = invocation.getArguments();
+                final Callback callback = (Callback) args[ 1 ];
+                callback.onSuccess( false );
+                return null;
+            }
+        } ).when( handler ).acceptContext( any( ProjectContext.class ),
+                                           any( Callback.class ) );
+
+        menu.onProjectContextChanged( event );
+
+        final List<MenuItem> menus = menu.getMenuItems();
+        final MenuItem mi = menus.get( 0 );
+        assertFalse( mi.isEnabled() );
+    }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/GUVNOR-2293

The "New Project" menu item now routes direct to the "New Project Wizard". Additional changes were made to move validation of the project name to the ```POMEditorPanel``` used by the Wizard; as the previous sole point of validation (```NewResourceView```) is now by-passed.