### PR TITLE
Prevent constraint fail when there is no identity on request scope

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/java/org/kie/workbench/common/screens/social/hp/security/UserCDIContextHelper.java
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/java/org/kie/workbench/common/screens/social/hp/security/UserCDIContextHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.social.hp.security;
+
+
+import org.jboss.errai.security.shared.api.identity.User;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.ContextNotActiveException;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class UserCDIContextHelper {
+
+    @Inject
+    private User identity;
+
+
+    public UserCDIContextHelper() {
+    }
+
+    public boolean thereIsALoggedUserInScope() {
+        try {
+            if ( identity == null ) {
+                return false;
+            }
+            checkIfThereIsAValidUserOnRequestScope();
+        } catch ( ContextNotActiveException c ) {
+            return false;
+        }
+        return true;
+    }
+
+    private void checkIfThereIsAValidUserOnRequestScope() {
+        identity.getIdentifier();
+    }
+
+    public User getUser() {
+        return identity;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/test/org/kie/workbench/common/screens/social/hp/security/UserCDIContextHelperTest.java
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-backend/src/main/test/org/kie/workbench/common/screens/social/hp/security/UserCDIContextHelperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.social.hp.security;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.enterprise.context.ContextNotActiveException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith( MockitoJUnitRunner.class )
+public class UserCDIContextHelperTest {
+
+    @Mock
+    User identify;
+
+    @InjectMocks
+    UserCDIContextHelper helper;
+
+    @Test
+    public void getUserTest() {
+        assertEquals( identify, helper.getUser() );
+    }
+
+    @Test
+    public void thereIsALoggedUserIsScope() {
+        assertTrue( helper.thereIsALoggedUserInScope() );
+    }
+
+    @Test
+    public void thereIsntALoggedUserIsScope() {
+        when( identify.getIdentifier() ).thenThrow( ContextNotActiveException.class );
+
+        assertFalse( helper.thereIsALoggedUserInScope() );
+    }
+
+    @Test
+    public void thereIsntALoggedUserIsScopeWithoutCDI() {
+        UserCDIContextHelper helperWithoutCdi = new UserCDIContextHelper();
+
+        assertFalse( helperWithoutCdi.thereIsALoggedUserInScope() );
+    }
+
+}


### PR DESCRIPTION
Prevent constraint fail when there is no identity on request scope
=================================================

Motivation
--------------
Recently, Kie Uberfire Social had received a PR creating a pluggable constraints mechanism for social timelines.

All the current implementations depend on User injection in order to apply the constraints to a social event, however, in the startup of app server social creates an in-memory cache for social events.

In that moment, there is no User injected on request scope, so if we apply this constraint to the timeline throws a ContextNotActiveException.

Solution
-----------

In order to prevent this, I've created a new class called UserCDIContextHelper. In that class, I check if there is a request scope for the user in runtime. The only way that I've found to do that is that ugly hack:

      public boolean thereIsALoggedUserInScope() {
        try {
             if ( identity == null ) {
                 return false;
             }
             checkIfThereIsAValidUserOnRequestScope();
         } catch ( ContextNotActiveException c ) {
            return false;
         }
         return true;
     }
 
    private void checkIfThereIsAValidUserOnRequestScope() {
         identity.getIdentifier();
    }

This seems like a lack of CDI 1.0 feature. If someone has a better implementation to that I'm open to change it.

Child PR
------------
https://github.com/droolsjbpm/kie-uberfire-extensions/pull/16