### PR TITLE
BZ1284782: Full Text search throws exception in special case

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-backend/src/main/java/org/kie/workbench/common/screens/search/backend/server/SearchServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-backend/src/main/java/org/kie/workbench/common/screens/search/backend/server/SearchServiceImpl.java
@@ -181,8 +181,15 @@ public class SearchServiceImpl implements SearchService {
         for ( final Path path : pathResult ) {
             final org.uberfire.backend.vfs.Path vfsPath = Paths.convert( path );
             final KieProject project = projectService.resolveProject( vfsPath );
-            if ( authorizationManager.authorize( project,
-                                                 identity ) ) {
+
+            //All Users are granted access to Resources outside the Project structure
+            boolean authorized = true;
+            if ( project != null ) {
+                authorized = authorizationManager.authorize( project,
+                                                             identity );
+            }
+
+            if ( authorized ) {
                 hits++;
                 final DublinCoreView dcoreView = ioService.getFileAttributeView( path,
                                                                                  DublinCoreView.class );

--- a/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-backend/src/test/java/org/kie/workbench/common/screens/search/backend/server/SearchServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-backend/src/test/java/org/kie/workbench/common/screens/search/backend/server/SearchServiceImplTest.java
@@ -393,4 +393,120 @@ public class SearchServiceImplTest {
                       results.getTotalRowSize() );
     }
 
+    @Test
+    public void testFullTextSearchOutsideProjectStructure() {
+        //Setup access rights - Grant access to all OUs
+        when( authorizationManager.authorize( ou1,
+                                              identity ) ).thenReturn( true );
+        when( authorizationManager.authorize( ou2,
+                                              identity ) ).thenReturn( true );
+
+        //Setup access rights - Grant access to all Repositories
+        when( authorizationManager.authorize( repo1,
+                                              identity ) ).thenReturn( true );
+        when( authorizationManager.authorize( repo2,
+                                              identity ) ).thenReturn( true );
+
+        //Setup access rights - Grant access to Project1
+        when( authorizationManager.authorize( project1,
+                                              identity ) ).thenReturn( true );
+
+        final SearchTermPageRequest pageRequest = new SearchTermPageRequest( "smurf",
+                                                                             0,
+                                                                             5 );
+
+        //Setup search
+        final org.uberfire.backend.vfs.Path vfsPath = PathFactory.newPath( "file1", "default://project1/file1" );
+        final Path nioPath = Paths.convert( vfsPath );
+        when( ioSearchService.fullTextSearchHits( eq( "smurf" ),
+                                                  Matchers.<Path>anyVararg() ) ).thenReturn( 1 );
+        when( ioSearchService.fullTextSearch( eq( "smurf" ),
+                                              any( Integer.class ),
+                                              any( Integer.class ),
+                                              Matchers.<Path>anyVararg() ) ).thenReturn( new ArrayList<Path>() {{
+            add( nioPath );
+        }} );
+
+        when( projectService.resolveProject( any( org.uberfire.backend.vfs.Path.class ) ) ).thenReturn( null );
+
+        final DublinCoreView dublinCoreView = mock( DublinCoreView.class );
+        final OtherMetaView otherMetaView = mock( OtherMetaView.class );
+        final VersionAttributeView versionAttributeView = mock( VersionAttributeView.class );
+        when( dublinCoreView.readAttributes() ).thenReturn( new DublinCoreAttributesMock() );
+        when( versionAttributeView.readAttributes() ).thenReturn( new VersionAttributesMock( Collections.EMPTY_LIST ) );
+        when( ioService.getFileAttributeView( any( Path.class ),
+                                              eq( DublinCoreView.class ) ) ).thenReturn( dublinCoreView );
+        when( ioService.getFileAttributeView( any( Path.class ),
+                                              eq( OtherMetaView.class ) ) ).thenReturn( otherMetaView );
+        when( ioService.getFileAttributeView( any( Path.class ),
+                                              eq( VersionAttributeView.class ) ) ).thenReturn( versionAttributeView );
+
+        //Perform search
+        final PageResponse<SearchPageRow> results = searchService.fullTextSearch( pageRequest );
+        assertEquals( 1,
+                      results.getTotalRowSize() );
+        assertEquals( vfsPath.getFileName(),
+                      results.getPageRowList().get( 0 ).getPath().getFileName() );
+    }
+
+    @Test
+    public void testMetadataSearchOutsideProjectStructure() {
+        //Setup access rights - Grant access to all OUs
+        when( authorizationManager.authorize( ou1,
+                                              identity ) ).thenReturn( true );
+        when( authorizationManager.authorize( ou2,
+                                              identity ) ).thenReturn( true );
+
+        //Setup access rights - Grant access to all Repositories
+        when( authorizationManager.authorize( repo1,
+                                              identity ) ).thenReturn( true );
+        when( authorizationManager.authorize( repo2,
+                                              identity ) ).thenReturn( true );
+
+        //Setup access rights - Grant access to Project1
+        when( authorizationManager.authorize( project1,
+                                              identity ) ).thenReturn( true );
+
+        final QueryMetadataPageRequest pageRequest = new QueryMetadataPageRequest( Collections.EMPTY_MAP,
+                                                                                   null,
+                                                                                   null,
+                                                                                   null,
+                                                                                   null,
+                                                                                   0,
+                                                                                   5 );
+
+        //Setup search
+        final org.uberfire.backend.vfs.Path vfsPath = PathFactory.newPath( "file1", "default://project1/file1" );
+        final Path nioPath = Paths.convert( vfsPath );
+        when( ioSearchService.searchByAttrsHits( any( Map.class ),
+                                                 Matchers.<Path>anyVararg() ) ).thenReturn( 1 );
+        when( ioSearchService.searchByAttrs( any( Map.class ),
+                                             any( Integer.class ),
+                                             any( Integer.class ),
+                                             Matchers.<Path>anyVararg() ) ).thenReturn( new ArrayList<Path>() {{
+            add( nioPath );
+        }} );
+
+        when( projectService.resolveProject( any( org.uberfire.backend.vfs.Path.class ) ) ).thenReturn( null );
+
+        final DublinCoreView dublinCoreView = mock( DublinCoreView.class );
+        final OtherMetaView otherMetaView = mock( OtherMetaView.class );
+        final VersionAttributeView versionAttributeView = mock( VersionAttributeView.class );
+        when( dublinCoreView.readAttributes() ).thenReturn( new DublinCoreAttributesMock() );
+        when( versionAttributeView.readAttributes() ).thenReturn( new VersionAttributesMock( Collections.EMPTY_LIST ) );
+        when( ioService.getFileAttributeView( any( Path.class ),
+                                              eq( DublinCoreView.class ) ) ).thenReturn( dublinCoreView );
+        when( ioService.getFileAttributeView( any( Path.class ),
+                                              eq( OtherMetaView.class ) ) ).thenReturn( otherMetaView );
+        when( ioService.getFileAttributeView( any( Path.class ),
+                                              eq( VersionAttributeView.class ) ) ).thenReturn( versionAttributeView );
+
+        //Perform search
+        final PageResponse<SearchPageRow> results = searchService.queryMetadata( pageRequest );
+        assertEquals( 1,
+                      results.getTotalRowSize() );
+        assertEquals( vfsPath.getFileName(),
+                      results.getPageRowList().get( 0 ).getPath().getFileName() );
+    }
+
 }


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1284782

```Project``` resolves to ```null``` for assets outside a Project structure (i.e. assets created by jBPM Designer in a ```global``` folder in the repository root).