### PR TITLE
GUVNOR-2302: Technical error message shown when trying to 'upload' assets without selecting a file

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidgetTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidgetTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.widget;
+
+import com.google.gwt.user.client.Command;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.Form;
+import org.gwtbootstrap3.client.ui.base.form.AbstractForm.SubmitCompleteHandler;
+import org.gwtbootstrap3.client.ui.base.form.AbstractForm.SubmitHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.widgets.common.client.common.FileUploadFormEncoder;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class AttachmentFileWidgetTest {
+
+    @InjectMocks
+    private AttachmentFileWidgetTestWrapper editor;
+
+    @GwtMock
+    private Form form;
+
+    @Mock
+    private FileUploadFormEncoder formEncoder;
+
+    @Mock
+    private Command successCallback;
+
+    @Mock
+    private Command errorCallback;
+
+    @Mock
+    private Path path;
+
+    @Before
+    public void setup() {
+        editor.forceInitForm( false );
+    }
+
+    @Test
+    public void formCharsetAdded() {
+        verify( formEncoder,
+                times( 1 ) ).addUtf8Charset( form );
+    }
+
+    @Test
+    public void formSubmitHandlersSet() {
+        verify( form,
+                never() ).addSubmitHandler( any( SubmitHandler.class ) );
+        verify( form,
+                times( 1 ) ).addSubmitCompleteHandler( any( SubmitCompleteHandler.class ) );
+    }
+
+    @Test
+    public void formSubmitValidState() {
+        editor.setValid( true );
+        editor.submit( path,
+                       "filename",
+                       "targetUrl",
+                       successCallback,
+                       errorCallback );
+        verify( form,
+                times( 1 ) ).submit();
+    }
+
+    @Test
+    public void formSubmitInvalidState() {
+        editor.setValid( false );
+        editor.submit( path,
+                       "filename",
+                       "targetUrl",
+                       successCallback,
+                       errorCallback );
+        verify( form,
+                never() ).submit();
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidgetTestWrapper.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/AttachmentFileWidgetTestWrapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.widget;
+
+public class AttachmentFileWidgetTestWrapper extends AttachmentFileWidget {
+
+    boolean initialized;
+    boolean isValid;
+
+    public AttachmentFileWidgetTestWrapper() {
+        super( false );
+    }
+
+    @Override
+    void setup( final boolean addFileUpload ) {
+        if ( initialized ) {
+            super.setup( addFileUpload );
+        }
+    }
+
+    void forceInitForm( final boolean addFileUpload ) {
+        this.initialized = true;
+        setup( addFileUpload );
+    }
+
+    void setValid( final boolean isValid ) {
+        this.isValid = isValid;
+    }
+
+    @Override
+    boolean isValid() {
+        return isValid;
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2302

The cause is the ```Form```'s ```SubmitHandler``` is broken in GWT-Bootstrap 3 (see gwtbootstrap3/gwtbootstrap3#375). The issue is fixed in GWT-Bootstrap 3 0.9.2 (we're on 0.9.1 at the moment). The fix is a work-around to move form validation to before we submit the form.