### PR TITLE
datamodel-backend: refactor duplicated test setup code + stabilize the tests

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
@@ -252,6 +252,11 @@
       <artifactId>jboss-logging</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceBaseTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/test/java/org/kie/workbench/common/screens/datamodeller/backend/server/DataModelerServiceBaseTest.java
@@ -21,6 +21,8 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 
 import org.jboss.weld.environment.se.StartMain;
+import org.jboss.weld.environment.se.Weld;
+import org.junit.After;
 import org.junit.Before;
 import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
 import org.kie.workbench.common.services.datamodeller.core.Annotation;
@@ -38,6 +40,7 @@ import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 public class DataModelerServiceBaseTest {
 
     protected final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
+    protected Weld weld;
     protected BeanManager beanManager;
     protected Paths paths;
     protected DataModelerService dataModelService;
@@ -46,9 +49,13 @@ public class DataModelerServiceBaseTest {
 
     @Before
     public void setUp() throws Exception {
+        // disable git and ssh daemons as they are not needed for the tests
+        System.setProperty( "org.uberfire.nio.git.daemon.enabled", "false" );
+        System.setProperty( "org.uberfire.nio.git.ssh.enabled", "false" );
+        System.setProperty( "org.uberfire.sys.repo.monitor.disabled", "true" );
         //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
+        weld = new Weld();
+        beanManager = weld.initialize().getBeanManager();
 
         //Instantiate Paths used in tests for Path conversion
         final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
@@ -111,6 +118,13 @@ public class DataModelerServiceBaseTest {
         }
 
         return annotation;
+    }
+
+    @After
+    public void tearDown() {
+        if (weld != null && beanManager != null) {
+            weld.shutdown();
+        }
     }
 
 }

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/AbstractDataModelWeldTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/AbstractDataModelWeldTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.workbench.common.services.datamodel.backend.server;
+
+import org.jboss.weld.environment.se.Weld;
+import org.junit.After;
+import org.junit.Before;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+abstract public class AbstractDataModelWeldTest {
+
+    protected final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
+    protected Weld weld;
+    protected BeanManager beanManager;
+    protected Paths paths;
+
+    @Before
+    public void setUp() throws Exception {
+        // disable git and ssh daemons as they are not needed for the tests
+        System.setProperty( "org.uberfire.nio.git.daemon.enabled", "false" );
+        System.setProperty( "org.uberfire.nio.git.ssh.enabled", "false" );
+        System.setProperty( "org.uberfire.sys.repo.monitor.disabled", "true" );
+        //Bootstrap WELD container
+        weld = new Weld();
+        beanManager = weld.initialize().getBeanManager();
+        //Instantiate Paths used in tests for Path conversion
+        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
+        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
+        paths = (Paths) beanManager.getReference( pathsBean,
+                Paths.class,
+                cc );
+
+        //Ensure URLs use the default:// scheme
+        fs.forceAsDefault();
+    }
+
+    @After
+    public void tearDown() {
+        // beanManager will be null in case weld.initialize() failed. And if that is the case the shutdown method
+        // would return NPE
+        if (weld != null && beanManager != null) {
+            weld.shutdown();
+        }
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelDeclaredTypesTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelDeclaredTypesTest.java
@@ -18,17 +18,12 @@ package org.kie.workbench.common.services.datamodel.backend.server;
 import java.net.URL;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
 
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
 import org.drools.workbench.models.datamodel.oracle.TypeSource;
-import org.jboss.weld.environment.se.StartMain;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
@@ -36,28 +31,7 @@ import static org.kie.workbench.common.services.datamodel.backend.server.Project
 /**
  * Tests for DataModelService
  */
-public class ProjectDataModelDeclaredTypesTest {
-
-    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
-    private BeanManager beanManager;
-    private Paths paths;
-
-    @Before
-    public void setUp() throws Exception {
-        //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
-
-        //Instantiate Paths used in tests for Path conversion
-        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
-        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
-        paths = (Paths) beanManager.getReference( pathsBean,
-                                                  Paths.class,
-                                                  cc );
-
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
-    }
+public class ProjectDataModelDeclaredTypesTest extends AbstractDataModelWeldTest {
 
     @Test
     public void testProjectDeclaredTypes() throws Exception {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelDependencyExclusionTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelDependencyExclusionTest.java
@@ -18,16 +18,11 @@ package org.kie.workbench.common.services.datamodel.backend.server;
 import java.net.URL;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
 
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
-import org.jboss.weld.environment.se.StartMain;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
@@ -35,28 +30,7 @@ import static org.kie.workbench.common.services.datamodel.backend.server.Project
 /**
  * Tests for DataModelService
  */
-public class ProjectDataModelDependencyExclusionTest {
-
-    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
-    private BeanManager beanManager;
-    private Paths paths;
-
-    @Before
-    public void setUp() throws Exception {
-        //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
-
-        //Instantiate Paths used in tests for Path conversion
-        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
-        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
-        paths = (Paths) beanManager.getReference( pathsBean,
-                                                  Paths.class,
-                                                  cc );
-
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
-    }
+public class ProjectDataModelDependencyExclusionTest extends AbstractDataModelWeldTest {
 
     @Test
     public void testBuilderExcludeTestProvidedScopeDependencies() throws Exception {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelExtendJavaTypeTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelExtendJavaTypeTest.java
@@ -18,16 +18,11 @@ package org.kie.workbench.common.services.datamodel.backend.server;
 import java.net.URL;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
 
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
-import org.jboss.weld.environment.se.StartMain;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
@@ -35,28 +30,7 @@ import static org.kie.workbench.common.services.datamodel.backend.server.Project
 /**
  * Tests for DataModelService
  */
-public class ProjectDataModelExtendJavaTypeTest {
-
-    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
-    private BeanManager beanManager;
-    private Paths paths;
-
-    @Before
-    public void setUp() throws Exception {
-        //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
-
-        //Instantiate Paths used in tests for Path conversion
-        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
-        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
-        paths = (Paths) beanManager.getReference( pathsBean,
-                                                  Paths.class,
-                                                  cc );
-
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
-    }
+public class ProjectDataModelExtendJavaTypeTest extends AbstractDataModelWeldTest {
 
     @Test
     public void testProjectExtendJavaTypeWithQualifiedDRLBeanName() throws Exception {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelPackageWhiteListTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelPackageWhiteListTest.java
@@ -18,16 +18,11 @@ package org.kie.workbench.common.services.datamodel.backend.server;
 import java.net.URL;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
 
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
-import org.jboss.weld.environment.se.StartMain;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
@@ -35,28 +30,7 @@ import static org.kie.workbench.common.services.datamodel.backend.server.Project
 /**
  * Tests for DataModelService
  */
-public class ProjectDataModelPackageWhiteListTest {
-
-    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
-    private BeanManager beanManager;
-    private Paths paths;
-
-    @Before
-    public void setUp() throws Exception {
-        //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
-
-        //Instantiate Paths used in tests for Path conversion
-        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
-        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
-        paths = (Paths) beanManager.getReference( pathsBean,
-                                                  Paths.class,
-                                                  cc );
-
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
-    }
+public class ProjectDataModelPackageWhiteListTest extends AbstractDataModelWeldTest {
 
     @Test
     public void testPackageNameWhiteList_EmptyWhiteList() throws Exception {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelRecursionTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelRecursionTest.java
@@ -18,16 +18,11 @@ package org.kie.workbench.common.services.datamodel.backend.server;
 import java.net.URL;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
 
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
-import org.jboss.weld.environment.se.StartMain;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
@@ -35,28 +30,7 @@ import static org.kie.workbench.common.services.datamodel.backend.server.Project
 /**
  * Tests for DataModelService
  */
-public class ProjectDataModelRecursionTest {
-
-    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
-    private BeanManager beanManager;
-    private Paths paths;
-
-    @Before
-    public void setUp() throws Exception {
-        //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
-
-        //Instantiate Paths used in tests for Path conversion
-        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
-        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
-        paths = (Paths) beanManager.getReference( pathsBean,
-                                                  Paths.class,
-                                                  cc );
-
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
-    }
+public class ProjectDataModelRecursionTest extends AbstractDataModelWeldTest {
 
     @Test
     public void testProjectDataModelOracle() throws Exception {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelServiceTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelServiceTest.java
@@ -18,16 +18,11 @@ package org.kie.workbench.common.services.datamodel.backend.server;
 import java.net.URL;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
 
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
-import org.jboss.weld.environment.se.StartMain;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
@@ -35,28 +30,7 @@ import static org.kie.workbench.common.services.datamodel.backend.server.Project
 /**
  * Tests for DataModelService
  */
-public class ProjectDataModelServiceTest {
-
-    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
-    private BeanManager beanManager;
-    private Paths paths;
-
-    @Before
-    public void setUp() throws Exception {
-        //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
-
-        //Instantiate Paths used in tests for Path conversion
-        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
-        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
-        paths = (Paths) beanManager.getReference( pathsBean,
-                                                  Paths.class,
-                                                  cc );
-
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
-    }
+public class ProjectDataModelServiceTest extends AbstractDataModelWeldTest {
 
     @Test
     public void testProjectDataModelOracle() throws Exception {

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelSuperTypesTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelSuperTypesTest.java
@@ -19,16 +19,11 @@ import java.net.URL;
 import java.util.HashSet;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
 
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
-import org.jboss.weld.environment.se.StartMain;
-import org.junit.Before;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.junit.Assert.*;
 import static org.kie.workbench.common.services.datamodel.backend.server.ProjectDataModelOracleTestUtils.*;
@@ -36,28 +31,7 @@ import static org.kie.workbench.common.services.datamodel.backend.server.Project
 /**
  * Tests for DataModelService
  */
-public class ProjectDataModelSuperTypesTest {
-
-    private final SimpleFileSystemProvider fs = new SimpleFileSystemProvider();
-    private BeanManager beanManager;
-    private Paths paths;
-
-    @Before
-    public void setUp() throws Exception {
-        //Bootstrap WELD container
-        StartMain startMain = new StartMain( new String[ 0 ] );
-        beanManager = startMain.go().getBeanManager();
-
-        //Instantiate Paths used in tests for Path conversion
-        final Bean pathsBean = (Bean) beanManager.getBeans( Paths.class ).iterator().next();
-        final CreationalContext cc = beanManager.createCreationalContext( pathsBean );
-        paths = (Paths) beanManager.getReference( pathsBean,
-                                                  Paths.class,
-                                                  cc );
-
-        //Ensure URLs use the default:// scheme
-        fs.forceAsDefault();
-    }
+public class ProjectDataModelSuperTypesTest extends AbstractDataModelWeldTest {
 
     @Test
     public void testProjectSuperTypes() throws Exception {


### PR DESCRIPTION
Build was locally successful 20 times in a row using `mvn clean install -T10`.

@wmedvede please take a look