### PR TITLE
GUVNOR-2315: All Asset Type sections in Project Explorer should be collapsed by default

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
@@ -184,7 +184,7 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
                 final LinkedGroup itemsNavList = new LinkedGroup();
                 itemsNavList.getElement().getStyle().setMarginBottom( 0, Style.Unit.PX );
                 final PanelCollapse collapse = new PanelCollapse();
-                collapse.setIn( true );
+                collapse.setIn( false );
                 collapse.setId( getCollapseId( entry.getKey() ) );
                 final PanelBody body = new PanelBody();
                 body.getElement().getStyle().setPadding( 0, Style.Unit.PX );


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2315