### PR TITLE
Guvnor 2309, 2310, 2315

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
@@ -16,25 +16,17 @@
 package org.kie.workbench.common.screens.explorer.client.widgets.business;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.uibinder.client.UiBinder;
-import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.common.services.project.model.Project;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.repositories.Repository;
@@ -68,6 +60,17 @@ import org.uberfire.client.workbench.type.AnyResourceType;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.ext.widgets.common.client.accordion.TriggerWidget;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
  * Business View implementation
@@ -108,6 +111,8 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
     @Inject
     User user;
 
+    private Map<String, PanelCollapse> collapses = new HashMap<String, PanelCollapse>();
+    
     //TreeSet sorts members upon insertion
     private final Set<FolderItem> sortedFolderItems = new TreeSet<FolderItem>( Sorters.ITEM_SORTER );
 
@@ -184,8 +189,11 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
                 final LinkedGroup itemsNavList = new LinkedGroup();
                 itemsNavList.getElement().getStyle().setMarginBottom( 0, Style.Unit.PX );
                 final PanelCollapse collapse = new PanelCollapse();
-                collapse.setIn( false );
-                collapse.setId( getCollapseId( entry.getKey() ) );
+                final String collapseId = getCollapseId( entry.getKey() );
+                final PanelCollapse oldCollapse = collapses.get( collapseId );
+                final boolean in = (oldCollapse != null) ? oldCollapse.isIn() : false;
+                collapse.setId( collapseId );
+                collapse.setIn( in );
                 final PanelBody body = new PanelBody();
                 body.getElement().getStyle().setPadding( 0, Style.Unit.PX );
                 collapse.add( body );
@@ -200,6 +208,8 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
                     add( makeTriggerWidget( entry.getKey(), collapse ) );
                     add( collapse );
                 }} );
+                
+                collapses.put( collapseId, collapse );
             }
         } else {
             itemsContainer.add( new Label( ProjectExplorerConstants.INSTANCE.noItemsExist() ) );

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/CommentLineViewImpl.ui.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/CommentLineViewImpl.ui.xml
@@ -24,7 +24,7 @@
   <ui:style>
     .general {
       height: 100%;
-      width: 200px;
+      min-width: 120px;
       font-size: 10px;
       padding: 3px 10px 3px 10px;
       margin: 3px 3px 3px 3px;

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetPresenter.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetPresenter.java
@@ -84,7 +84,4 @@ public class DiscussionWidgetPresenter
         }
     }
 
-    public void onResize() {
-        view.onResize();
-    }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetView.java
@@ -28,8 +28,6 @@ public interface DiscussionWidgetView
 
     }
 
-    void onResize();
-
     void setPresenter(Presenter presenter);
 
     void addRow(DiscussionRecord line);

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetViewImpl.java
@@ -72,7 +72,6 @@ public class DiscussionWidgetViewImpl
     @Override
     public void clear() {
         lines.clear();
-        clearCommentBox();
     }
 
     @Override

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetViewImpl.java
@@ -23,17 +23,13 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.common.services.shared.metadata.model.DiscussionRecord;
 import org.gwtbootstrap3.client.ui.TextArea;
 
-public class DiscussionWidgetViewImpl
-        extends Composite
-        implements DiscussionWidgetView,
-                   RequiresResize {
+public class DiscussionWidgetViewImpl extends Composite implements DiscussionWidgetView {
 
     private Presenter presenter;
 
@@ -89,16 +85,5 @@ public class DiscussionWidgetViewImpl
         if ( event.getNativeKeyCode() == KeyCodes.KEY_ENTER ) {
             presenter.onAddComment( textBox.getText() );
         }
-    }
-
-    @Override
-    public void onResize() {
-        int heightMaxParent = getParent().getParent().getParent().getParent().getParent().getParent().getOffsetHeight() - 40;
-        int heightVisible = getParent().getParent().getOffsetHeight() - 40;
-        int height = heightVisible > heightMaxParent ? heightVisible : heightMaxParent;
-
-        int scrollHeight = height - textBox.getOffsetHeight() - 100;
-        commentScroll.setHeight( scrollHeight + "px" );
-        setHeight( height + "px" );
     }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetViewImpl.ui.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/discussion/DiscussionWidgetViewImpl.ui.xml
@@ -31,6 +31,10 @@
     .comment {
       padding-top: 20px;
     }
+    
+    .commentScroll {
+      max-height: 360px; 
+    }
 
   </ui:style>
 
@@ -40,7 +44,7 @@
     </b:Row>
     <b:Row>
       <b:Column size="MD_12">
-        <gwt:ScrollPanel ui:field="commentScroll">
+        <gwt:ScrollPanel ui:field="commentScroll" addStyleNames="{style.commentScroll}">
           <gwt:VerticalPanel ui:field="lines"/>
         </gwt:ScrollPanel>
       </b:Column>

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/widget/OverviewWidgetViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/widget/OverviewWidgetViewImpl.java
@@ -27,7 +27,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.gwtbootstrap3.client.ui.NavTabs;
@@ -46,10 +45,7 @@ import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 import org.uberfire.java.nio.base.version.VersionRecord;
 import org.uberfire.mvp.ParameterizedCommand;
 
-public class OverviewWidgetViewImpl
-        extends Composite
-        implements OverviewScreenView,
-                   RequiresResize {
+public class OverviewWidgetViewImpl extends Composite implements OverviewScreenView {
 
     private static final int VERSION_HISTORY_TAB = 0;
 
@@ -237,11 +233,6 @@ public class OverviewWidgetViewImpl
 
     public void setForceUnlockHandler( final Runnable handler ) {
         this.metadata.setForceUnlockHandler( handler );
-    }
-
-    @Override
-    public void onResize() {
-        discussionArea.onResize();
     }
 
     @Override


### PR DESCRIPTION
**Contains 3 commits**

*View/Layout changes only*

GUVNOR-2309: Comments section in overview uses inefficient layout
GUVNOR-2310: When commenting on an unlocked asset, the first (few) char(s) of the comment are removed
GUVNOR-2315: Improved fix so the users current asset type collapse state stays in place in case the project explorer gets refreshed (i.e. new file gets added or lock state changes)

