### PR TITLE
JBPM-4777 - Data Modeller fixes after the BS3 migration

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/PersistenceDescriptorEditorViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/PersistenceDescriptorEditorViewImpl.java
@@ -20,6 +20,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -27,8 +28,11 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Widget;
+import org.gwtbootstrap3.client.shared.event.ShowEvent;
+import org.gwtbootstrap3.client.shared.event.ShowHandler;
 import org.gwtbootstrap3.client.ui.HelpBlock;
 import org.gwtbootstrap3.client.ui.PanelBody;
+import org.gwtbootstrap3.client.ui.PanelCollapse;
 import org.gwtbootstrap3.client.ui.Radio;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.kie.workbench.common.screens.datamodeller.client.pdescriptor.PersistenceUnitPropertyGrid;
@@ -76,10 +80,16 @@ public class PersistenceDescriptorEditorViewImpl
     HelpBlock transactionTypeHelpInline;
 
     @UiField
+    PanelCollapse collapsePropertiesPanel;
+
+    @UiField
     PanelBody propertiesGridPanel;
 
     @Inject
     PersistenceUnitPropertyGrid persistenceUnitProperties;
+
+    @UiField
+    PanelCollapse collapsePersistencePanel;
 
     @UiField
     PanelBody persistenceUnitClassesPanel;
@@ -100,6 +110,28 @@ public class PersistenceDescriptorEditorViewImpl
     void init() {
         propertiesGridPanel.add( persistenceUnitProperties );
         persistenceUnitClassesPanel.add( persistenceUnitClasses );
+        collapsePropertiesPanel.addShowHandler( new ShowHandler() {
+            @Override
+            public void onShow( ShowEvent showEvent ) {
+                Scheduler.get().scheduleDeferred( new Scheduler.ScheduledCommand() {
+                    @Override
+                    public void execute() {
+                        persistenceUnitProperties.redraw();
+                    }
+                } );
+            }
+        } );
+        collapsePersistencePanel.addShowHandler( new ShowHandler() {
+            @Override
+            public void onShow( ShowEvent showEvent ) {
+                Scheduler.get().scheduleDeferred( new Scheduler.ScheduledCommand() {
+                    @Override
+                    public void execute() {
+                        persistenceUnitClasses.redraw();
+                    }
+                } );
+            }
+        } );
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/PersistenceDescriptorEditorViewImpl.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/PersistenceDescriptorEditorViewImpl.ui.xml
@@ -87,7 +87,7 @@
                                         <b:Anchor text="{i18n.persistence_descriptor_editor_advanced_properties_table}" addStyleNames="collapsed" dataToggle="COLLAPSE" dataTarget="#collapseProperties"/>
                                     </b:Heading>
                                 </b:PanelHeader>
-                                <b:PanelCollapse b:id="collapseProperties">
+                                <b:PanelCollapse b:id="collapseProperties" ui:field="collapsePropertiesPanel">
                                     <b:PanelBody ui:field="propertiesGridPanel"/>
                                 </b:PanelCollapse>
                             </b:Panel>
@@ -100,7 +100,7 @@
                                         <b:Anchor text="{i18n.persistence_descriptor_editor_persistable_objects_table}" addStyleNames="collapsed" dataToggle="COLLAPSE" dataTarget="#collapsePersistence" />
                                     </b:Heading>
                                 </b:PanelHeader>
-                                <b:PanelCollapse b:id="collapsePersistence">
+                                <b:PanelCollapse b:id="collapsePersistence" ui:field="collapsePersistencePanel">
                                     <b:PanelBody ui:field="persistenceUnitClassesPanel"/>
                                 </b:PanelCollapse>
                             </b:Panel>


### PR DESCRIPTION
    - Persistence unit classes were not shown when the persistable data object section were expanded. Now fixed.

    - Persistence unit properties were not shown when the advanced properties section were expended. Now fixed.