### PR TITLE
Fixes after upgrade to IP BOM 6.0.0.Final

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/pom.xml
@@ -221,6 +221,11 @@
       <artifactId>errai-security-picketlink</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
 * the additional dependeny is need to make WELD tests happy.
   IP BOM 6.0.0.Final contains different version of Picketlink
   (the one used in EAP) and it probably does not depend on the
   persistence-api itself, but in fact requires the EMF at some
   injection point

Needs to be merged together with: https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/123