### PR TITLE
BZ1296498: [GSS] (6.2.z) Opening a repository takes a long time in BRMS 6.2

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImpl.java
@@ -15,23 +15,19 @@
  */
 package org.kie.workbench.common.screens.explorer.backend.server;
 
-import static java.util.Collections.emptyList;
-import static org.uberfire.commons.validation.PortablePreconditions.checkNotEmpty;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.SessionScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.thoughtworks.xstream.XStream;
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.project.events.DeleteProjectEvent;
 import org.guvnor.common.services.project.events.RenameProjectEvent;
@@ -74,7 +70,8 @@ import org.uberfire.java.nio.file.StandardDeleteOption;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.security.authz.AuthorizationManager;
 
-import com.thoughtworks.xstream.XStream;
+import static java.util.Collections.*;
+import static org.uberfire.commons.validation.PortablePreconditions.*;
 
 @Service
 @ApplicationScoped
@@ -127,7 +124,7 @@ public class ExplorerServiceImpl
 
     @Inject
     private RepositoryService repositoryService;
-    
+
     @Inject
     private VFSLockServiceImpl lockService;
 
@@ -222,7 +219,8 @@ public class ExplorerServiceImpl
                                            final FolderItem item,
                                            final ActiveOptions options ) {
         //TODO: BUSINESS_CONTENT, TECHNICAL_CONTENT
-        final FolderListing result = helper.getFolderListing( item );
+        final FolderListing result = helper.getFolderListing( item,
+                                                              options );
 
         if ( result != null ) {
             final org.uberfire.java.nio.file.Path userNavPath = userServices.buildPath( "explorer", "user.nav" );
@@ -328,8 +326,8 @@ public class ExplorerServiceImpl
 
             for ( final Path path : paths ) {
                 final LockInfo lockInfo = lockService.retrieveLockInfo( path );
-                checkLockState(path, lockInfo);
-                
+                checkLockState( path, lockInfo );
+
                 ioService.deleteIfExists( Paths.convert( path ),
                                           new CommentedOption( sessionInfo.getId(),
                                                                identity.getIdentifier(),
@@ -347,11 +345,12 @@ public class ExplorerServiceImpl
         }
     }
 
-    private void checkLockState( final Path path, final LockInfo lockInfo ) {
+    private void checkLockState( final Path path,
+                                 final LockInfo lockInfo ) {
         if ( lockInfo.isLocked() && !identity.getIdentifier().equals( lockInfo.lockedBy() ) ) {
             throw new RuntimeException( path.toURI() + " is locked by: " + lockInfo.lockedBy() );
         }
-        
+
         final List<LockInfo> lockInfos = lockService.retrieveLockInfos( path, true );
         if ( !lockInfos.isEmpty() ) {
             throw new RuntimeException( path.toURI() + " contains the following locked files: " + lockInfos );
@@ -370,8 +369,8 @@ public class ExplorerServiceImpl
 
             for ( final Path path : paths ) {
                 final LockInfo lockInfo = lockService.retrieveLockInfo( path );
-                checkLockState(path, lockInfo);
-                
+                checkLockState( path, lockInfo );
+
                 final org.uberfire.java.nio.file.Path _path = Paths.convert( path );
 
                 if ( Files.exists( _path ) ) {

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/FolderListingResolver.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/FolderListingResolver.java
@@ -70,18 +70,22 @@ public class FolderListingResolver {
         if ( selectedItem == null ) {
             if ( options.contains( Option.BUSINESS_CONTENT ) ) {
                 result = new FolderListing( toFolderItem( getDefaultPackage() ),
-                                            helper.getItems( getDefaultPackage() ),
+                                            helper.getItems( getDefaultPackage(),
+                                                             options ),
                                             getSegments() );
             } else {
-                result = helper.getFolderListing( selectedProject.getRootPath() );
+                result = helper.getFolderListing( selectedProject.getRootPath(),
+                                                  options );
             }
         } else {
-            result = helper.getFolderListing( selectedItem );
+            result = helper.getFolderListing( selectedItem,
+                                              options );
         }
 
         if ( selectedPackage != null && result == null ) {
             result = new FolderListing( toFolderItem( selectedPackage ),
-                                        helper.getItems( selectedPackage ),
+                                        helper.getItems( selectedPackage,
+                                                         options ),
                                         helper.getPackageSegments( selectedPackage ) );
         }
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceHelperTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceHelperTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.explorer.backend.server;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.guvnor.common.services.backend.file.LinkedFilter;
+import org.guvnor.common.services.backend.metadata.attribute.OtherMetaView;
+import org.guvnor.common.services.project.model.Package;
+import org.guvnor.common.services.shared.metadata.MetadataService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.explorer.model.FolderItem;
+import org.kie.workbench.common.screens.explorer.service.ActiveOptions;
+import org.kie.workbench.common.screens.explorer.service.Option;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.server.UserServicesImpl;
+import org.uberfire.backend.server.VFSLockServiceImpl;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExplorerServiceHelperTest {
+
+    private SimpleFileSystemProvider fileSystemProvider;
+
+    @Mock
+    private KieProjectService projectService;
+
+    @Mock
+    private FolderListingResolver folderListingResolver;
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private IOService ioServiceConfig;
+
+    @Mock
+    private OtherMetaView otherMetaView;
+
+    @Mock
+    private VFSLockServiceImpl lockService;
+
+    @Mock
+    private MetadataService metadataService;
+
+    @Mock
+    private UserServicesImpl userServices;
+
+    @Mock
+    private Package pkg;
+
+    @Mock
+    private Path srcPath;
+
+    @Mock
+    private Path srcTestPath;
+
+    @Mock
+    private Path srcResourcesPath;
+
+    @Mock
+    private Path testResourcesPath;
+
+    private org.uberfire.java.nio.file.Path path;
+    private ExplorerServiceHelper helper;
+
+    private final List<String> tags = new ArrayList<String>() {{
+        add( "tag" );
+    }};
+
+    @Before
+    public void setUp() throws Exception {
+        fileSystemProvider = new SimpleFileSystemProvider();
+
+        //Ensure URLs use the default:// scheme
+        fileSystemProvider.forceAsDefault();
+
+        path = fileSystemProvider.getPath( this.getClass().getResource( "myfile.file" ).toURI() );
+
+        when( srcPath.toURI() ).thenReturn( path.toUri().toString() );
+        when( srcTestPath.toURI() ).thenReturn( path.toUri().toString() );
+        when( srcResourcesPath.toURI() ).thenReturn( path.toUri().toString() );
+        when( testResourcesPath.toURI() ).thenReturn( path.toUri().toString() );
+
+        when( pkg.getPackageMainSrcPath() ).thenReturn( srcPath );
+        when( pkg.getPackageTestSrcPath() ).thenReturn( srcTestPath );
+        when( pkg.getPackageMainResourcesPath() ).thenReturn( srcResourcesPath );
+        when( pkg.getPackageTestResourcesPath() ).thenReturn( testResourcesPath );
+
+        when( metadataService.getTags( any( Path.class ) ) ).thenReturn( tags );
+
+        when( ioService.newDirectoryStream( any( org.uberfire.java.nio.file.Path.class ),
+                                            any( LinkedFilter.class ) ) ).thenReturn( new DirectoryStreamMock() {
+
+            private List<org.uberfire.java.nio.file.Path> items = new ArrayList<org.uberfire.java.nio.file.Path>() {{
+                add( path );
+            }};
+
+            @Override
+            public Iterator<org.uberfire.java.nio.file.Path> iterator() {
+                return items.iterator();
+            }
+        } );
+
+        helper = new ExplorerServiceHelper( projectService,
+                                            folderListingResolver,
+                                            ioService,
+                                            ioServiceConfig,
+                                            lockService,
+                                            metadataService,
+                                            userServices );
+    }
+
+    @Test
+    public void testGetItemsWithoutTags() {
+        final ActiveOptions options = new ActiveOptions();
+        final List<FolderItem> fis = helper.getItems( pkg,
+                                                      options );
+
+        assertNotNull( fis );
+        assertEquals( 4,
+                      fis.size() );
+
+        assertEquals( 0,
+                      fis.get( 0 ).getTags().size() );
+        assertEquals( 0,
+                      fis.get( 1 ).getTags().size() );
+        assertEquals( 0,
+                      fis.get( 2 ).getTags().size() );
+        assertEquals( 0,
+                      fis.get( 3 ).getTags().size() );
+    }
+
+    @Test
+    public void testGetItemsWithTags() {
+        final ActiveOptions options = new ActiveOptions( Option.SHOW_TAG_FILTER );
+        final List<FolderItem> fis = helper.getItems( pkg,
+                                                      options );
+
+        assertNotNull( fis );
+        assertEquals( 4,
+                      fis.size() );
+
+        assertEquals( 1,
+                      fis.get( 0 ).getTags().size() );
+        assertEquals( 1,
+                      fis.get( 1 ).getTags().size() );
+        assertEquals( 1,
+                      fis.get( 2 ).getTags().size() );
+        assertEquals( 1,
+                      fis.get( 3 ).getTags().size() );
+    }
+
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1296498

The issue was introduced by BPMSPL-100 which added support for "tag filtering". This PR makes retrieval of tag meta-data optional only when "tag filtering" is enabled in the UI.