### PR TITLE
Fix PackageDataModelMethodsTest.testMethodsOnJavaClass_TreeMap for JDK1.7 and JDK1.8

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelMethodsTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelMethodsTest.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.widgets.client.datamodel;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -32,7 +31,6 @@ import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
 import org.jboss.errai.common.client.api.Caller;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodel.backend.server.builder.packages.PackageDataModelOracleBuilder;
-import org.kie.workbench.common.services.datamodel.backend.server.builder.projects.FactBuilder;
 import org.kie.workbench.common.services.datamodel.backend.server.builder.projects.ProjectDataModelOracleBuilder;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
 import org.kie.workbench.common.services.datamodel.service.IncrementalDataModelService;
@@ -40,7 +38,7 @@ import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.callbacks.Callback;
 
 import static org.junit.Assert.*;
-import static org.kie.workbench.common.widgets.client.datamodel.PackageDataModelOracleTestUtils.assertContains;
+import static org.kie.workbench.common.widgets.client.datamodel.PackageDataModelOracleTestUtils.*;
 import static org.mockito.Mockito.*;
 
 public class PackageDataModelMethodsTest {
@@ -85,8 +83,6 @@ public class PackageDataModelMethodsTest {
                                new Callback<List<MethodInfo>>() {
                                    @Override
                                    public void callback( final List<MethodInfo> mis ) {
-                                       assertEquals( 33,
-                                                     mis.size() );
                                        assertContains( "ceilingEntry",
                                                        mis );
                                        assertContains( "ceilingKey",


### PR DESCRIPTION
@psiroky Test fixed, as requested. 

I've simply removed the check on the number of methods provided by ```TreeMap``` (which is changing from JDK to JDK).