### PR TITLE
GUVNOR-2306 : Project Editor KModule settings widget needs cleanup

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/widgets/ListFormComboPanelViewImpl.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/widgets/ListFormComboPanelViewImpl.ui.xml
@@ -26,7 +26,7 @@
 
     <b:Container fluid="true">
         <b:Row>
-            <b:Column size="MD_4">
+            <b:Column size="MD_3">
                 <b:ButtonGroup>
                     <b:Button ui:field="addButton">
                         <ui:text from="{i18n.Add}"/>
@@ -43,9 +43,7 @@
                 </b:ButtonGroup>
                 <b:ListBox ui:field="list" visibleItemCount="15"/>
             </b:Column>
-        </b:Row>
-        <b:Row>
-            <b:Column size="MD_12" ui:field="kSessionForm" />
+            <b:Column size="MD_9" ui:field="kSessionForm" />
         </b:Row>
     </b:Container>
 


### PR DESCRIPTION
After the change the list of kbases and the form appeared on separate rows.
The old design placed these next to each other. Returned the look to what it used to be.