### PR TITLE
GUVNOR-2308: Project explorer minimize/maximize button overlaps with breadcrumbs

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
@@ -49,6 +49,7 @@ import org.kie.workbench.common.screens.explorer.client.widgets.View;
 import org.kie.workbench.common.screens.explorer.client.widgets.branches.BranchChangeHandler;
 import org.kie.workbench.common.screens.explorer.client.widgets.branches.BranchSelector;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.Explorer;
+import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorExpandCollapseButton;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorOptions;
 import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagSelector;
 import org.kie.workbench.common.screens.explorer.model.FolderItem;
@@ -138,7 +139,7 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
     @Override
     public void init( final BaseViewPresenter presenter ) {
         this.presenter = presenter;
-        explorer.init( Explorer.Mode.COLLAPSED, businessOptions, Explorer.NavType.TREE, presenter );
+        explorer.init( NavigatorExpandCollapseButton.Mode.COLLAPSED, businessOptions, Explorer.NavType.TREE, presenter );
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/NavigatorExpandCollapseButton.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/navigator/NavigatorExpandCollapseButton.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.explorer.client.widgets.navigator;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.Composite;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.gwtbootstrap3.client.ui.constants.Pull;
+
+public class NavigatorExpandCollapseButton extends Composite {
+
+    public enum Mode {
+        EXPANDED, COLLAPSED
+    }
+
+    private Mode mode;
+
+    private Button button;
+
+    public NavigatorExpandCollapseButton( final Mode mode ) {
+        this.mode = mode;
+        configureButton();
+    }
+
+    private void configureButton() {
+        this.button = GWT.create( Button.class );
+        initWidget( button );
+        button.setPull( Pull.RIGHT );
+        button.getElement().getStyle().setMarginTop( 10, Style.Unit.PX );
+        button.getElement().getStyle().setMarginBottom( 10, Style.Unit.PX );
+
+        if ( mode.equals( Mode.COLLAPSED )) {
+            button.setIcon( IconType.CHEVRON_DOWN );
+        } else {
+            button.setIcon( IconType.CHEVRON_UP );
+        }
+    }
+
+    public void addClickHandler( final ClickHandler clickHandler ) {
+        button.addClickHandler( clickHandler );
+    }
+
+    public void invertMode() {
+        if ( mode.equals( Mode.COLLAPSED )) {
+            this.mode = Mode.EXPANDED;
+            button.setIcon( IconType.CHEVRON_UP );
+        } else {
+            this.mode = Mode.COLLAPSED;
+            button.setIcon( IconType.CHEVRON_DOWN );
+        }
+    }
+
+    public boolean isExpanded() {
+        return Mode.EXPANDED.equals( this.mode );
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/technical/TechnicalViewWidget.java
@@ -36,6 +36,7 @@ import org.kie.workbench.common.screens.explorer.client.widgets.View;
 import org.kie.workbench.common.screens.explorer.client.widgets.branches.BranchChangeHandler;
 import org.kie.workbench.common.screens.explorer.client.widgets.branches.BranchSelector;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.Explorer;
+import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorExpandCollapseButton;
 import org.kie.workbench.common.screens.explorer.client.widgets.navigator.NavigatorOptions;
 import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagChangedEvent;
 import org.kie.workbench.common.screens.explorer.client.widgets.tagSelector.TagSelector;
@@ -95,7 +96,7 @@ public class TechnicalViewWidget
     @Override
     public void init( final BaseViewPresenter presenter ) {
         this.presenter = presenter;
-        explorer.init( Explorer.Mode.EXPANDED,
+        explorer.init( NavigatorExpandCollapseButton.Mode.EXPANDED,
                        techOptions,
                        Explorer.NavType.BREADCRUMB,
                        presenter );


### PR DESCRIPTION
When the project explorer is wide, it looks like that:
![image1](https://cloud.githubusercontent.com/assets/832830/12481229/d14c2a3c-c02e-11e5-837e-b44ceb45230a.png)

and when it is narrow, it looks like that:
![image2](https://cloud.githubusercontent.com/assets/832830/12481232/d69c32de-c02e-11e5-8350-f1f7adb3078a.png)