### PR TITLE
GUVNOR-2373: Modal for artifacts table in Project editor-Dependencies is too small for the content

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyListWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyListWidget.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
+import org.guvnor.m2repo.client.resources.i18n.M2RepoEditorConstants;
 import org.guvnor.m2repo.client.widgets.ArtifactListPresenter;
 import org.guvnor.m2repo.client.widgets.ArtifactListView;
 import org.guvnor.m2repo.model.JarListPageRow;
@@ -37,6 +38,7 @@ import org.gwtbootstrap3.client.ui.constants.ButtonSize;
 import org.gwtbootstrap3.client.ui.gwt.ButtonCell;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.container.IOC;
+import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
 import org.uberfire.mvp.ParameterizedCommand;
 
 @Dependent
@@ -77,9 +79,26 @@ public class DependencyListWidget
     public void init() {
         dependencyPagedJarTable = IOC.getBeanManager().lookupBean( ArtifactListPresenter.class ).getInstance();
 
+        // Column to view KJAR's pom
+        final Column<JarListPageRow, String> openColumn = new Column<JarListPageRow, String>( new ButtonCell( ButtonSize.EXTRA_SMALL ) ) {
+            @Override
+            public String getValue( JarListPageRow row ) {
+                return M2RepoEditorConstants.INSTANCE.Open();
+            }
+        };
+        openColumn.setFieldUpdater( new FieldUpdater<JarListPageRow, String>() {
+            @Override
+            public void update( int index,
+                                JarListPageRow row,
+                                String value ) {
+                dependencyPagedJarTable.onOpenPom( row.getPath() );
+            }
+        } );
+
+        // Column to allow selection of dependency
         final Column<JarListPageRow, String> selectColumn = new Column<JarListPageRow, String>( new ButtonCell( ButtonSize.EXTRA_SMALL ) ) {
             public String getValue( JarListPageRow row ) {
-                return "Select";
+                return ProjectEditorResources.CONSTANTS.Select();
             }
         };
         selectColumn.setFieldUpdater( new FieldUpdater<JarListPageRow, String>() {
@@ -91,10 +110,20 @@ public class DependencyListWidget
         } );
         final ArtifactListView artifactListView = dependencyPagedJarTable.getView();
 
-        artifactListView.addColumn( selectColumn, "Select" );
+        artifactListView.addColumn( openColumn,
+                                    M2RepoEditorConstants.INSTANCE.Open(),
+                                    false,
+                                    100.0,
+                                    Style.Unit.PX );
+        artifactListView.addColumn( selectColumn,
+                                    ProjectEditorResources.CONSTANTS.Select(),
+                                    100.0,
+                                    Style.Unit.PX );
         artifactListView.setContentHeight( "200px" );
-        artifactListView.asWidget().getElement().getStyle().setMarginLeft( 0, Style.Unit.PX );
-        artifactListView.asWidget().getElement().getStyle().setMarginRight( 0, Style.Unit.PX );
+        artifactListView.asWidget().getElement().getStyle().setMarginLeft( 0,
+                                                                           Style.Unit.PX );
+        artifactListView.asWidget().getElement().getStyle().setMarginRight( 0,
+                                                                            Style.Unit.PX );
 
         panel.add( artifactListView );
     }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencySelectorPopupViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencySelectorPopupViewImpl.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 
 import org.gwtbootstrap3.client.shared.event.ModalShownEvent;
 import org.gwtbootstrap3.client.shared.event.ModalShownHandler;
+import org.gwtbootstrap3.client.ui.ModalSize;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.uberfire.client.mvp.LockRequiredEvent;
@@ -51,6 +52,7 @@ public class DependencySelectorPopupViewImpl
 
         setTitle( "Artifacts" );
         setBody( dependencyPagedJarTable );
+        setSize( ModalSize.LARGE );
 
         //Need to refresh the grid to load content after the popup is shown
         addShownHandler( new ModalShownHandler() {

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/ProjectEditorResources.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/ProjectEditorResources.java
@@ -26,12 +26,12 @@ public interface ProjectEditorResources
         extends
         ClientBundle {
 
-    public ProjectEditorResources INSTANCE = GWT.create(ProjectEditorResources.class);
+    ProjectEditorResources INSTANCE = GWT.create(ProjectEditorResources.class);
 
-    public ProjectEditorConstants CONSTANTS = GWT.create(ProjectEditorConstants.class);
+    ProjectEditorConstants CONSTANTS = GWT.create(ProjectEditorConstants.class);
 
     @Source("css/ProjectEditor.css")
-    public ProjectEditorCss mainCss();
+    ProjectEditorCss mainCss();
 
     @Source("images/error.gif")
     ImageResource Error();
@@ -48,7 +48,7 @@ public interface ProjectEditorResources
     @Source("images/newProject.gif")
     ImageResource newProjectIcon();
 
-
     @Source("images/newFolder.gif")
     ImageResource newFolderIcon();
+
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.java
@@ -303,4 +303,6 @@ public interface ProjectEditorConstants
 
     String RepositoryInclude();
 
+    String Select();
+
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/resources/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/resources/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.properties
@@ -156,3 +156,4 @@ Repositories=Repositories
 ResolvedRepositories=Resolved repositories
 RepositoriesExplanation=These are the Maven Repositories resolved for the Project from the Project''s pom, the Project''s Distribution Management configuration and Maven''s global settings.
 RepositoryInclude=Include
+Select=Select


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2373

This PR just adjusts the columns shown in the ```DependencyListWidget``` following changes in ```guvnor``` (see referenced PR). Fixes an i18n issue too.