### PR TITLE
Fix i18ed label in User perspective

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/src/main/java/org/kie/workbench/common/screens/social/hp/client/resources/i18n/Constants.java
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/src/main/java/org/kie/workbench/common/screens/social/hp/client/resources/i18n/Constants.java
@@ -41,6 +41,8 @@ public interface Constants
 
     String UserProfile();
 
+    String UserInfo();
+
     String UserRecentActivities();
 
     String SearchUsers();

--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/src/main/java/org/kie/workbench/common/screens/social/hp/client/userpage/side/SideUserInfoView.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/src/main/java/org/kie/workbench/common/screens/social/hp/client/userpage/side/SideUserInfoView.ui.xml
@@ -38,7 +38,7 @@
 
     <b:FieldSet>
         <b:Legend>
-            <small><ui:text from="{i18n.SearchUsers}" /></small>
+            <small><ui:text from="{i18n.UserInfo}" /></small>
         </b:Legend>
         <g:FlowPanel ui:field="userPanel" addStyleNames="text-center"/>
         <b:Description horizontal="true" addStyleNames="{style.user-attribute}">

--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/src/main/resources/org/kie/workbench/common/screens/social/hp/client/resources/i18n/Constants.properties
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/src/main/resources/org/kie/workbench/common/screens/social/hp/client/resources/i18n/Constants.properties
@@ -23,6 +23,7 @@ LatestChanges=Latest Changes
 AllRepositories=All Repositories
 ShowingUpdatesFor=Showing updates for
 UserProfile=&#39s Profile
+UserInfo=User Info
 UserRecentActivities=&#39s Recent Activities
 SearchUsers=Search users
 UserName=Username


### PR DESCRIPTION
Fix mistake in commit a47dce6 which (by copy/paste error probably) replaced 
"User Info" label by "Search User" - see screenshot.

![issue](https://cloud.githubusercontent.com/assets/2716069/13041773/6c97db6e-d3ba-11e5-9244-352032b07a6f.png)
