### PR TITLE
[master] In exec.server UI, switch from KeyUpHandler to ChangeHandler.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/config/rules/ContainerRulesConfigView.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/container/config/rules/ContainerRulesConfigView.java
@@ -23,8 +23,8 @@ import javax.inject.Inject;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.KeyUpEvent;
-import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Composite;
@@ -114,9 +114,9 @@ public class ContainerRulesConfigView extends Composite
 
     @PostConstruct
     public void init() {
-        version.addKeyUpHandler( new KeyUpHandler() {
+        version.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( !version.getText().trim().isEmpty() ) {
                     StyleHelper.addUniqueEnumStyleName( versionForm, ValidationState.class, ValidationState.NONE );
                 }
@@ -124,9 +124,9 @@ public class ContainerRulesConfigView extends Composite
         } );
         version.getElement().setAttribute( "placeholder", getVersionTextBoxPlaceholder() );
 
-        interval.addKeyUpHandler( new KeyUpHandler() {
+        interval.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( !interval.getText().trim().isEmpty() ) {
                     StyleHelper.addUniqueEnumStyleName( scannerForm, ValidationState.class, ValidationState.NONE );
                 }

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/navigation/template/copy/CopyPopupView.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/navigation/template/copy/CopyPopupView.java
@@ -20,8 +20,8 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.KeyUpEvent;
-import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Composite;
@@ -72,9 +72,9 @@ public class CopyPopupView extends Composite
     @Override
     public void init( final CopyPopupPresenter presenter ) {
         this.presenter = presenter;
-        templateName.addKeyUpHandler( new KeyUpHandler() {
+        templateName.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( !templateName.getText().trim().isEmpty() ) {
                     StyleHelper.addUniqueEnumStyleName( templateNameGroup, ValidationState.class, ValidationState.NONE );
                     templateNameHelp.setVisible( false );

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormView.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/container/NewContainerFormView.java
@@ -21,8 +21,8 @@ import javax.inject.Inject;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
-import com.google.gwt.event.dom.client.KeyUpEvent;
-import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Composite;
 import org.gwtbootstrap3.client.ui.TextBox;
@@ -90,9 +90,9 @@ public class NewContainerFormView extends Composite
 
     @Override
     public void init( final NewContainerFormPresenter presenter ) {
-        containerName.addKeyUpHandler( new KeyUpHandler() {
+        containerName.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( presenter.isContainerNameValid() ) {
                     noErrorOnContainerName();
                 } else {
@@ -102,9 +102,9 @@ public class NewContainerFormView extends Composite
             }
         } );
 
-        groupId.addKeyUpHandler( new KeyUpHandler() {
+        groupId.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( presenter.isGroupIdValid() ) {
                     noErrorOnGroupId();
                 } else {
@@ -114,9 +114,9 @@ public class NewContainerFormView extends Composite
             }
         } );
 
-        artifactId.addKeyUpHandler( new KeyUpHandler() {
+        artifactId.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( presenter.isArtifactIdValid() ) {
                     noErrorOnArtifactId();
                 } else {
@@ -126,9 +126,9 @@ public class NewContainerFormView extends Composite
             }
         } );
 
-        version.addKeyUpHandler( new KeyUpHandler() {
+        version.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( presenter.isVersionValid() ) {
                     noErrorOnVersion();
                 } else {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/template/NewTemplateView.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/wizard/template/NewTemplateView.java
@@ -24,8 +24,8 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.KeyUpEvent;
-import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Composite;
 import org.gwtbootstrap3.client.ui.CheckBox;
@@ -87,9 +87,9 @@ public class NewTemplateView extends Composite
         processEnabled.setText( getProcessCheckBoxText() );
         planningEnabled.setText( getPlanningCheckBoxText() );
 
-        templateName.addKeyUpHandler( new KeyUpHandler() {
+        templateName.addChangeHandler( new ChangeHandler() {
             @Override
-            public void onKeyUp( KeyUpEvent event ) {
+            public void onChange( ChangeEvent event ) {
                 if ( presenter.isTemplateNameValid() ) {
                     noErrorOnTemplateName();
                 } else {


### PR DESCRIPTION
See also GUVNOR-2386 - keyUp tends to mess up focus. This is
a simple copy of the fix mention in GUVNOR-2386.

(cherry picked from commit 2b4f1acad53964a2937f3ee11c0cbce5e32affa2)