### PR TITLE
[6.4.x] GUVNOR-2362: Project Explorer freezes after uploading an item with an extension-free name

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/pom.xml
@@ -129,6 +129,19 @@
       <scope>provided</scope>
     </dependency>
 
+    <!--Tests-->
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/test/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploaderTest.java
+++ b/kie-wb-common-screens/kie-wb-common-default-editor/kie-wb-common-default-editor-client/src/test/java/org/kie/workbench/common/screens/defaulteditor/client/editor/NewFileUploaderTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.defaulteditor.client.editor;
+
+import javax.enterprise.event.Event;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.ext.widgets.core.client.editors.defaulteditor.DefaultEditorNewFileUpload;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.Command;
+import org.uberfire.workbench.events.NotificationEvent;
+import org.uberfire.workbench.type.AnyResourceTypeDefinition;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NewFileUploaderTest {
+
+    @Mock
+    private PlaceManager placeManager;
+
+    @GwtMock
+    private DefaultEditorNewFileUpload options;
+
+    private AnyResourceTypeDefinition resourceType = new AnyResourceTypeDefinition();
+
+    @Mock
+    private BusyIndicatorView busyIndicatorView;
+
+    @Mock
+    private org.guvnor.common.services.project.model.Package pkg;
+
+    @Mock
+    private Path pkgResourcesPath;
+
+    @Mock
+    private NewResourcePresenter presenter;
+
+    private Event<NotificationEvent> mockNotificationEvent = new EventSourceMock<NotificationEvent>() {
+        @Override
+        public void fire( final NotificationEvent event ) {
+            //Do nothing. Default implementation throws an Exception
+        }
+    };
+
+    private NewFileUploader uploader;
+
+    @Before
+    public void setup() {
+        uploader = new NewFileUploader( placeManager,
+                                        options,
+                                        resourceType,
+                                        busyIndicatorView ) {
+            {
+                super.notificationEvent = mockNotificationEvent;
+            }
+
+            @Override
+            String encode( final String uri ) {
+                //Tests don't concern themselves with URI encoding
+                return uri;
+            }
+        };
+        when( pkg.getPackageMainResourcesPath() ).thenReturn( pkgResourcesPath );
+        when( pkgResourcesPath.toURI() ).thenReturn( "default://p0/src/main/resources" );
+        when( options.getFormFileName() ).thenReturn( "file.txt" );
+    }
+
+    @Test
+    public void testCreateFileNameWithExtension() {
+        uploader.create( pkg,
+                         "file.txt",
+                         presenter );
+
+        verify( busyIndicatorView,
+                times( 1 ) ).showBusyIndicator( any( String.class ) );
+        verify( options,
+                times( 1 ) ).setFileName( "file.txt" );
+        verify( options,
+                times( 1 ) ).upload( any( Command.class ),
+                                     any( Command.class ) );
+    }
+
+    @Test
+    public void testCreateFileNameWithoutExtension() {
+        uploader.create( pkg,
+                         "file",
+                         presenter );
+
+        verify( busyIndicatorView,
+                times( 1 ) ).showBusyIndicator( any( String.class ) );
+        verify( options,
+                times( 1 ) ).setFileName( "file.txt" );
+        verify( options,
+                times( 1 ) ).upload( any( Command.class ),
+                                     any( Command.class ) );
+    }
+
+    @Test
+    public void testCreateSuccess() {
+        final ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass( Command.class );
+        final ArgumentCaptor<Path> pathArgumentCaptor = ArgumentCaptor.forClass( Path.class );
+
+        uploader.create( pkg,
+                         "file",
+                         presenter );
+
+        verify( busyIndicatorView,
+                times( 1 ) ).showBusyIndicator( any( String.class ) );
+        verify( options,
+                times( 1 ) ).upload( commandArgumentCaptor.capture(),
+                                     any( Command.class ) );
+
+        //Emulate a successful upload
+        final Command command = commandArgumentCaptor.getValue();
+        assertNotNull( command );
+
+        command.execute();
+
+        verify( busyIndicatorView,
+                times( 1 ) ).hideBusyIndicator();
+        verify( presenter,
+                times( 1 ) ).complete();
+        verify( placeManager,
+                times( 1 ) ).goTo( pathArgumentCaptor.capture() );
+
+        //Check navigation
+        final Path routedPath = pathArgumentCaptor.getValue();
+        assertEquals( "default://p0/src/main/resources/file.txt",
+                      routedPath.toURI() );
+    }
+
+    @Test
+    public void testCreateFailure() {
+        final ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass( Command.class );
+
+        uploader.create( pkg,
+                         "file",
+                         presenter );
+
+        verify( busyIndicatorView,
+                times( 1 ) ).showBusyIndicator( any( String.class ) );
+        verify( options,
+                times( 1 ) ).upload( any( Command.class ),
+                                     commandArgumentCaptor.capture() );
+
+        //Emulate a successful upload
+        final Command command = commandArgumentCaptor.getValue();
+        assertNotNull( command );
+
+        command.execute();
+
+        verify( busyIndicatorView,
+                times( 1 ) ).hideBusyIndicator();
+        verify( presenter,
+                never() ).complete();
+        verify( placeManager,
+                never() ).goTo( any( Path.class ) );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/DefaultNewResourceHandler.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/DefaultNewResourceHandler.java
@@ -63,10 +63,10 @@ public abstract class DefaultNewResourceHandler implements NewResourceHandler,
     protected Caller<ValidationService> validationService;
 
     @Inject
-    private PlaceManager placeManager;
+    protected PlaceManager placeManager;
 
     @Inject
-    private Event<NotificationEvent> notificationEvent;
+    protected Event<NotificationEvent> notificationEvent;
 
     @Inject
     private BusyIndicatorView busyIndicatorView;


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2362

This is the corollary of https://github.com/droolsjbpm/kie-wb-common/pull/2996 for 0.8.x

(cherry picked from commit bc32d5e55805a644d68834a7663c0a489e4f673c)

Branch name is consistent across Uberfire and KIE to help Jenkins CI.
