### PR TITLE
GUVNOR-2352 : Adding of manual dependency does not work correctly

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/ArtifactIdColumn.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/ArtifactIdColumn.java
@@ -17,9 +17,10 @@ package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies
 
 import org.guvnor.common.services.project.model.Dependency;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 public class ArtifactIdColumn
-        extends com.google.gwt.user.cellview.client.Column<org.guvnor.common.services.project.model.Dependency, String> {
+        extends com.google.gwt.user.cellview.client.Column<EnhancedDependency, String> {
 
     public ArtifactIdColumn( DependencyGridViewImpl.RedrawCommand redrawCommand ) {
         super( new WaterMarkEditTextCell( ProjectEditorResources.CONSTANTS.EnterAnArtifactID() ) );
@@ -29,9 +30,9 @@ public class ArtifactIdColumn
     }
 
     @Override
-    public String getValue( Dependency dependency ) {
-        if ( dependency.getArtifactId() != null ) {
-            return dependency.getArtifactId();
+    public String getValue( EnhancedDependency dependency ) {
+        if ( dependency.getDependency().getArtifactId() != null ) {
+            return dependency.getDependency().getArtifactId();
         } else {
             return "";
         }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/ArtifactIdDependencyFieldUpdater.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/ArtifactIdDependencyFieldUpdater.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies
 import com.google.gwt.user.client.Window;
 import org.guvnor.common.services.project.model.Dependency;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 public class ArtifactIdDependencyFieldUpdater
         extends DependencyFieldUpdater {
@@ -34,8 +35,8 @@ public class ArtifactIdDependencyFieldUpdater
     }
 
     @Override
-    protected void setValue( final Dependency dependency,
+    protected void setValue( final EnhancedDependency dependency,
                              final String value ) {
-        dependency.setArtifactId( value );
+        dependency.getDependency().setArtifactId( value );
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyFieldUpdater.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyFieldUpdater.java
@@ -17,8 +17,8 @@ package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies
 
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.user.client.Window;
-import org.guvnor.common.services.project.model.Dependency;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 /**
  * <p>Custom field updater for handling dependency GAV values.</p>
@@ -33,7 +33,7 @@ import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEd
  * <p/>
  */
 public abstract class DependencyFieldUpdater
-        implements FieldUpdater<Dependency, String> {
+        implements FieldUpdater<EnhancedDependency, String> {
 
     private final WaterMarkEditTextCell cell;
     private final DependencyGridViewImpl.RedrawCommand redrawCommand;
@@ -46,7 +46,7 @@ public abstract class DependencyFieldUpdater
 
     @Override
     public void update( int index,
-                        Dependency dependency,
+                        EnhancedDependency dependency,
                         String value ) {
         if ( validate( value ) ) {
             setValue( dependency,
@@ -73,7 +73,7 @@ public abstract class DependencyFieldUpdater
         Window.alert( ProjectEditorResources.CONSTANTS.XMLMarkIsNotAllowed() );
     }
 
-    protected abstract void setValue( final Dependency dep,
+    protected abstract void setValue( final EnhancedDependency dep,
                                       final String value );
 
     protected abstract void reportEmpty();

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyGridView.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyGridView.java
@@ -16,10 +16,8 @@
 
 package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
 
-import java.util.List;
-
 import com.google.gwt.user.client.ui.IsWidget;
-import org.guvnor.common.services.project.model.Dependency;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
 import org.kie.workbench.common.services.shared.whitelist.WhiteList;
 
 public interface DependencyGridView
@@ -29,10 +27,13 @@ public interface DependencyGridView
 
     void setReadOnly();
 
-    void show( final List<Dependency> dependencies );
+    void show( final EnhancedDependencies enhancedDependencies );
 
     void setWhiteList( WhiteList whiteList );
 
     void redraw();
 
+    void showLoading();
+
+    void hideBusyIndicator();
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyGridViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyGridViewImpl.java
@@ -15,8 +15,6 @@
  */
 package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
 
-import java.util.List;
-
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -25,11 +23,13 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
-import org.guvnor.common.services.project.model.Dependency;
 import org.gwtbootstrap3.client.ui.Button;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 import org.kie.workbench.common.services.shared.whitelist.WhiteList;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
+import org.uberfire.ext.widgets.common.client.common.BusyPopup;
 import org.uberfire.ext.widgets.common.client.tables.SimpleTable;
 import org.uberfire.mvp.Command;
 
@@ -38,7 +38,7 @@ public class DependencyGridViewImpl
         implements DependencyGridView {
 
     @UiField( provided = true )
-    SimpleTable<Dependency> dataGrid = new SimpleTable<Dependency>();
+    SimpleTable<EnhancedDependency> dataGrid = new SimpleTable<EnhancedDependency>();
 
     interface Binder
             extends
@@ -87,11 +87,11 @@ public class DependencyGridViewImpl
     private void addRemoveRowColumn() {
         RemoveColumn column = new RemoveColumn();
 
-        column.setFieldUpdater( new FieldUpdater<Dependency, String>() {
+        column.setFieldUpdater( new FieldUpdater<EnhancedDependency, String>() {
             @Override
-            public void update( int index,
-                                Dependency dependency,
-                                String value ) {
+            public void update( final int index,
+                                final EnhancedDependency dependency,
+                                final String value ) {
                 presenter.onRemoveDependency( dependency );
             }
         } );
@@ -127,8 +127,8 @@ public class DependencyGridViewImpl
     }
 
     @Override
-    public void show( final List<Dependency> dependencies ) {
-        dataGrid.setRowData( dependencies );
+    public void show( final EnhancedDependencies dependencies ) {
+        dataGrid.setRowData( dependencies.asList() );
         dataGrid.redraw();
     }
 
@@ -141,6 +141,16 @@ public class DependencyGridViewImpl
     @Override
     public void redraw() {
         dataGrid.redraw();
+    }
+
+    @Override
+    public void showLoading() {
+        BusyPopup.showMessage( CommonConstants.INSTANCE.Loading() );
+    }
+
+    @Override
+    public void hideBusyIndicator() {
+        BusyPopup.close();
     }
 
     class RedrawCommand

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoader.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoader.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.kie.workbench.common.services.shared.dependencies.DependencyService;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
+
+@Dependent
+public class DependencyLoader {
+
+    private final List<Dependency> updateQueue = new ArrayList<>();
+
+    private final Caller<DependencyService>   dependencyService;
+    private       EnhancedDependenciesManager manager;
+
+    @Inject
+    public DependencyLoader( final Caller<DependencyService> dependencyService ) {
+        this.dependencyService = dependencyService;
+    }
+
+    public void init( final EnhancedDependenciesManager manager ) {
+        this.manager = manager;
+        this.updateQueue.clear();
+    }
+
+    public void load() {
+        if ( !updateQueue.isEmpty() ) {
+            loadFromServer();
+        } else {
+            returnDefault();
+        }
+    }
+
+    private void returnDefault() {
+        EnhancedDependencies enhancedDependencies = new EnhancedDependencies();
+        for ( Dependency dependency : updateQueue ) {
+            enhancedDependencies.add( new NormalEnhancedDependency( dependency,
+                                                                    new HashSet<String>() ) );
+        }
+
+        updateQueue.clear();
+
+        manager.onEnhancedDependenciesUpdated( enhancedDependencies );
+    }
+
+    private void loadFromServer() {
+
+        dependencyService.call( new RemoteCallback<EnhancedDependencies>() {
+                                    @Override
+                                    public void callback( final EnhancedDependencies result ) {
+                                        onLoadSuccess( result );
+                                    }
+                                },
+                                new ErrorCallback<Object>() {
+                                    @Override
+                                    public boolean error( final Object o,
+                                                          final Throwable throwable ) {
+
+
+                                        returnDefault();
+                                        return false;
+                                    }
+                                } ).loadEnhancedDependencies( updateQueue );
+    }
+
+    private void onLoadSuccess( final EnhancedDependencies result ) {
+        updateQueue.clear();
+        manager.onEnhancedDependenciesUpdated( result );
+    }
+
+    public void addToQueue( final Dependency dependency ) {
+        updateQueue.add( dependency );
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import java.util.Collection;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.model.Dependencies;
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.common.services.project.model.POM;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
+import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
+import org.uberfire.client.callbacks.Callback;
+
+/**
+ * By default the dependencies in POM do not include the information about the packages each Dependency contains.
+ * Neither do they include the transitive dependencies.
+ * We can use this class to enhance the list and fill in the packages.
+ */
+@Dependent
+public class EnhancedDependenciesManager {
+
+    private final EnhancedDependencies enhancedDependencies = new EnhancedDependencies();
+    private final DependencyLoader loader;
+
+    private Callback<EnhancedDependencies> callback;
+    private Dependencies                   originalSetOfDependencies;
+
+    @Inject
+    public EnhancedDependenciesManager( final DependencyLoader loader ) {
+        this.loader = loader;
+    }
+
+    public void init( final POM pom,
+                      final Callback<EnhancedDependencies> callback ) {
+
+        loader.init( this );
+
+        this.originalSetOfDependencies = pom.getDependencies();
+        this.enhancedDependencies.clear();
+
+        addToQueue( originalSetOfDependencies.getGavs( "compile" ) );
+
+        this.callback = callback;
+    }
+
+    private void addToQueue( final Collection<GAV> originalSetOfDependencies ) {
+        for ( final GAV gav : originalSetOfDependencies ) {
+            loader.addToQueue( getDependency( gav ) );
+        }
+    }
+
+    private Dependency getDependency( final GAV gav ) {
+        for ( final Dependency originalSetOfDependency : originalSetOfDependencies ) {
+            if ( originalSetOfDependency.isGAVEqual( gav ) ) {
+                return originalSetOfDependency;
+            }
+        }
+
+        return null;
+    }
+
+    public void update() {
+        loader.load();
+    }
+
+    void onEnhancedDependenciesUpdated( final EnhancedDependencies loadedEnhancedDependencies ) {
+        for ( final EnhancedDependency enhancedDependency : loadedEnhancedDependencies ) {
+
+            updateOriginal( enhancedDependency );
+
+            updateEnhanced( enhancedDependency );
+        }
+
+        callback.callback( this.enhancedDependencies );
+    }
+
+    private void updateEnhanced( final EnhancedDependency enhancedDependency ) {
+        if ( this.enhancedDependencies.contains( enhancedDependency ) ) {
+            this.enhancedDependencies.update( enhancedDependency );
+        } else {
+            this.enhancedDependencies.add( enhancedDependency );
+        }
+    }
+
+    private void updateOriginal( final EnhancedDependency enhancedDependency ) {
+        if ( enhancedDependency instanceof NormalEnhancedDependency ) {
+            updateWithOriginalDependency( ( NormalEnhancedDependency ) enhancedDependency );
+        }
+    }
+
+    private void updateWithOriginalDependency( final NormalEnhancedDependency enhancedDependency ) {
+        final Dependency originalDependency = originalSetOfDependencies.get( enhancedDependency.getDependency() );
+        enhancedDependency.setDependency( originalDependency );
+    }
+
+    public void delete( final EnhancedDependency enhancedDependency ) {
+        enhancedDependencies.remove( enhancedDependency );
+        originalSetOfDependencies.remove( enhancedDependency.getDependency() );
+        update();
+    }
+
+    public void addNew( final Dependency dependency ) {
+        originalSetOfDependencies.add( dependency );
+        loader.addToQueue( dependency );
+        update();
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/GroupIdColumn.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/GroupIdColumn.java
@@ -18,9 +18,10 @@ package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies
 import com.google.gwt.user.cellview.client.Column;
 import org.guvnor.common.services.project.model.Dependency;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 public class GroupIdColumn
-        extends Column<Dependency, String> {
+        extends Column<EnhancedDependency, String> {
 
     public GroupIdColumn( DependencyGridViewImpl.RedrawCommand redrawCommand ) {
         super( new WaterMarkEditTextCell( ProjectEditorResources.CONSTANTS.EnterAGroupID() ) );
@@ -30,9 +31,9 @@ public class GroupIdColumn
     }
 
     @Override
-    public String getValue( Dependency dependency ) {
-        if ( dependency.getGroupId() != null ) {
-            return dependency.getGroupId();
+    public String getValue( EnhancedDependency dependency ) {
+        if ( dependency.getDependency().getGroupId() != null ) {
+            return dependency.getDependency().getGroupId();
         } else {
             return "";
         }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/GroupIdDependencyFieldUpdater.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/GroupIdDependencyFieldUpdater.java
@@ -16,8 +16,8 @@
 package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
 
 import com.google.gwt.user.client.Window;
-import org.guvnor.common.services.project.model.Dependency;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 public class GroupIdDependencyFieldUpdater
         extends DependencyFieldUpdater {
@@ -34,8 +34,8 @@ public class GroupIdDependencyFieldUpdater
     }
 
     @Override
-    protected void setValue( final Dependency dep,
+    protected void setValue( final EnhancedDependency dep,
                              final String value ) {
-        dep.setGroupId( value );
+        dep.getDependency().setGroupId( value );
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopup.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopup.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+import org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.validation.DependencyValidator;
+import org.uberfire.client.callbacks.Callback;
+
+@Dependent
+public class NewDependencyPopup {
+
+    private final NewDependencyPopupView view;
+    private       DependencyValidator    validator;
+
+    private Dependency dependency;
+
+    private Callback<Dependency> callback;
+
+    @Inject
+    public NewDependencyPopup( final NewDependencyPopupView view ) {
+        this.view = view;
+        view.setPresenter( this );
+    }
+
+    public void show( final Callback<Dependency> callback ) {
+        this.callback = callback;
+        dependency = new Dependency();
+        validator = new DependencyValidator( dependency );
+        view.clean();
+        view.show();
+    }
+
+    public void onOkClicked() {
+
+        if ( validator.validate() ) {
+            callback.callback( dependency );
+            view.hide();
+        } else {
+            validateGroupId();
+            validateArtifactId();
+            validateVersion();
+        }
+    }
+
+    public void onGroupIdChange( final String groupId ) {
+        dependency.setGroupId( groupId );
+        validateGroupId();
+    }
+
+    public void validateGroupId() {
+        if ( validator.validateGroupId() ) {
+            view.invalidGroupId( "" );
+            view.setGroupIdValidationState( ValidationState.SUCCESS );
+        } else {
+            view.invalidGroupId( validator.getMessage() );
+            view.setGroupIdValidationState( ValidationState.ERROR );
+        }
+    }
+
+    public void onArtifactIdChange( final String artifactId ) {
+        dependency.setArtifactId( artifactId );
+        validateArtifactId();
+    }
+
+    public void validateArtifactId() {
+        if ( validator.validateArtifactId() ) {
+            view.invalidArtifactId( "" );
+            view.setArtifactIdValidationState( ValidationState.SUCCESS );
+        } else {
+            view.invalidArtifactId( validator.getMessage() );
+            view.setArtifactIdValidationState( ValidationState.ERROR );
+        }
+    }
+
+    public void onVersionChange( final String version ) {
+        dependency.setVersion( version );
+        validateVersion();
+    }
+
+    public void validateVersion() {
+        if ( validator.validateVersion() ) {
+            view.invalidVersion( "" );
+            view.setVersionValidationState( ValidationState.SUCCESS );
+        } else {
+            view.invalidVersion( validator.getMessage() );
+            view.setVersionValidationState( ValidationState.ERROR );
+        }
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupView.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupView.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+
+public interface NewDependencyPopupView {
+
+    void show();
+
+    void setPresenter( final NewDependencyPopup newDependencyPopup );
+
+    void hide();
+
+    void invalidGroupId( final String errorMessage );
+
+    void invalidArtifactId( final String errorMessage );
+
+    void invalidVersion( final String errorMessage );
+
+    void setGroupIdValidationState( final ValidationState validationState );
+
+    void setArtifactIdValidationState( final ValidationState validationState );
+
+    void setVersionValidationState( final ValidationState validationState );
+
+    void clean();
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupViewImpl.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+import org.gwtbootstrap3.client.ui.Form;
+import org.gwtbootstrap3.client.ui.FormGroup;
+import org.gwtbootstrap3.client.ui.HelpBlock;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKCancelButtons;
+
+public class NewDependencyPopupViewImpl
+        extends BaseModal
+        implements NewDependencyPopupView {
+
+    private static Binder uiBinder = GWT.create( Binder.class );
+
+    @UiField
+    TextBox groupIdTextBox;
+
+    @UiField
+    TextBox artifactIdTextBox;
+
+    @UiField
+    TextBox versionTextBox;
+
+    @UiField
+    HelpBlock groupIdHelpBlock;
+
+    @UiField
+    HelpBlock artifactIdHelpBlock;
+
+    @UiField
+    HelpBlock versionHelpBlock;
+
+    @UiField
+    FormGroup groupIdFromGroup;
+
+    @UiField
+    FormGroup artifactIdFromGroup;
+
+    @UiField
+    FormGroup versionFromGroup;
+
+    private NewDependencyPopup presenter;
+
+    public NewDependencyPopupViewImpl() {
+        setTitle( ProjectEditorResources.CONSTANTS.Dependency() );
+        setBody( uiBinder.createAndBindUi( this ) );
+        add( new ModalFooterOKCancelButtons(
+                     new com.google.gwt.user.client.Command() {
+                         @Override
+                         public void execute() {
+                             presenter.onOkClicked();
+                         }
+                     },
+                     new com.google.gwt.user.client.Command() {
+                         @Override
+                         public void execute() {
+                             hide();
+                         }
+                     }
+             )
+           );
+    }
+
+    @Override
+    public void setPresenter( final NewDependencyPopup presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void invalidGroupId( final String errorMessage ) {
+        groupIdHelpBlock.setText( errorMessage );
+    }
+
+    @Override
+    public void invalidArtifactId( final String errorMessage ) {
+        artifactIdHelpBlock.setText( errorMessage );
+    }
+
+    @Override
+    public void invalidVersion( final String errorMessage ) {
+        versionHelpBlock.setText( errorMessage );
+    }
+
+    @Override
+    public void setGroupIdValidationState( final ValidationState validationState ) {
+        groupIdFromGroup.setValidationState( validationState );
+    }
+
+    @Override
+    public void setArtifactIdValidationState( final ValidationState validationState ) {
+        artifactIdFromGroup.setValidationState( validationState );
+    }
+
+    @Override
+    public void setVersionValidationState( final ValidationState validationState ) {
+        versionFromGroup.setValidationState( validationState );
+    }
+
+    @Override
+    public void clean() {
+        groupIdTextBox.clear();
+        artifactIdTextBox.clear();
+        versionTextBox.clear();
+    }
+
+    @UiHandler( "groupIdTextBox" )
+    public void onGroupIdChange( final ValueChangeEvent<String> event ) {
+        presenter.onGroupIdChange( event.getValue() );
+    }
+
+    @UiHandler( "artifactIdTextBox" )
+    public void onArtifactIdChange( final ValueChangeEvent<String> event ) {
+        presenter.onArtifactIdChange( event.getValue() );
+    }
+
+    @UiHandler( "versionTextBox" )
+    public void onVersionChange( final ValueChangeEvent<String> event ) {
+        presenter.onVersionChange( event.getValue() );
+    }
+
+    @UiHandler( "groupIdTextBox" )
+    public void onGroupIdChangeTyped( final KeyUpEvent event ) {
+        presenter.onGroupIdChange( groupIdTextBox.getText() );
+    }
+
+    @UiHandler( "artifactIdTextBox" )
+    public void onArtifactIdChangeTyped( final KeyUpEvent event ) {
+        presenter.onArtifactIdChange( artifactIdTextBox.getText() );
+    }
+
+    @UiHandler( "versionTextBox" )
+    public void onVersionChange( final KeyUpEvent event ) {
+        presenter.onVersionChange( versionTextBox.getText() );
+    }
+
+    interface Binder extends UiBinder<Form, NewDependencyPopupViewImpl> {
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupViewImpl.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupViewImpl.ui.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:bootstrap='urn:import:org.gwtbootstrap3.client.ui'
+    >
+
+  <ui:with field="i18n" type="org.kie.workbench.common.screens.projecteditor.client.resources.i18n.ProjectEditorConstants"/>
+
+  <bootstrap:Form type="HORIZONTAL">
+    <bootstrap:FieldSet>
+
+      <bootstrap:FormGroup ui:field="groupIdFromGroup" validationState="NONE">
+        <bootstrap:FormLabel text='{i18n.GroupID}' addStyleNames="col-md-3"/>
+        <bootstrap:Column size="MD_9">
+          <bootstrap:TextBox ui:field="groupIdTextBox" placeholder="org.example"/>
+          <bootstrap:HelpBlock ui:field="groupIdHelpBlock"/>
+        </bootstrap:Column>
+      </bootstrap:FormGroup>
+
+      <bootstrap:FormGroup ui:field="artifactIdFromGroup" validationState="NONE">
+        <bootstrap:FormLabel text='{i18n.ArtifactID}' addStyleNames="col-md-3"/>
+        <bootstrap:Column size="MD_9">
+          <bootstrap:TextBox ui:field="artifactIdTextBox" placeholder="example"/>
+          <bootstrap:HelpBlock ui:field="artifactIdHelpBlock"/>
+        </bootstrap:Column>
+      </bootstrap:FormGroup>
+
+      <bootstrap:FormGroup ui:field="versionFromGroup" validationState="NONE">
+        <bootstrap:FormLabel text='{i18n.Version}' addStyleNames="col-md-3"/>
+        <bootstrap:Column size="MD_9">
+          <bootstrap:TextBox ui:field="versionTextBox" placeholder="1.0"/>
+          <bootstrap:HelpBlock ui:field="versionHelpBlock"/>
+        </bootstrap:Column>
+      </bootstrap:FormGroup>
+
+    </bootstrap:FieldSet>
+  </bootstrap:Form>
+</ui:UiBinder>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/RemoveColumn.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/RemoveColumn.java
@@ -17,11 +17,12 @@ package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies
 
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
-import org.guvnor.common.services.project.model.Dependency;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
+import org.kie.workbench.common.services.shared.dependencies.TransitiveEnhancedDependency;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 
 public class RemoveColumn
-        extends com.google.gwt.user.cellview.client.Column<Dependency, String> {
+        extends com.google.gwt.user.cellview.client.Column<EnhancedDependency, String> {
 
     public RemoveColumn( ) {
         super( new TrashCanImageCell() );
@@ -29,22 +30,22 @@ public class RemoveColumn
 
 
     @Override
-    public String getValue( Dependency dependency ) {
+    public String getValue( EnhancedDependency dependency ) {
         return CommonConstants.INSTANCE.Delete();
     }
 
     @Override
     public void render( final Cell.Context context,
-                        final Dependency dependency,
+                        final EnhancedDependency enhancedDependency,
                         final SafeHtmlBuilder sb ) {
 
-        (( TrashCanImageCell ) getCell()).setEnabled( !isTransitive( dependency ) );
+        (( TrashCanImageCell ) getCell()).setEnabled( !isTransitive( enhancedDependency ) );
 
-        super.render( context, dependency, sb );
+        super.render( context, enhancedDependency, sb );
 
     }
 
-    private boolean isTransitive( final Dependency dependency ) {
-        return "transitive".equals( dependency.getScope() );
+    private boolean isTransitive( final EnhancedDependency enhancedDependency ) {
+        return enhancedDependency instanceof TransitiveEnhancedDependency;
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/VersionColumn.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/VersionColumn.java
@@ -18,9 +18,10 @@ package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies
 import com.google.gwt.user.cellview.client.Column;
 import org.guvnor.common.services.project.model.Dependency;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 public class VersionColumn
-        extends Column<Dependency, String> {
+        extends Column<EnhancedDependency, String> {
 
     public VersionColumn( final DependencyGridViewImpl.RedrawCommand redrawCommand ) {
         super( new WaterMarkEditTextCell( ProjectEditorResources.CONSTANTS.EnterAVersion() ) );
@@ -30,9 +31,9 @@ public class VersionColumn
     }
 
     @Override
-    public String getValue( Dependency dependency ) {
-        if ( dependency.getVersion() != null ) {
-            return dependency.getVersion();
+    public String getValue( EnhancedDependency dependency ) {
+        if ( dependency.getDependency().getVersion() != null ) {
+            return dependency.getDependency().getVersion();
         } else {
             return "";
         }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/VersionDependencyFieldUpdater.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/VersionDependencyFieldUpdater.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies
 import com.google.gwt.user.client.Window;
 import org.guvnor.common.services.project.model.Dependency;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 public class VersionDependencyFieldUpdater
         extends DependencyFieldUpdater {
@@ -34,9 +35,9 @@ public class VersionDependencyFieldUpdater
     }
 
     @Override
-    protected void setValue( final Dependency dep,
+    protected void setValue( final EnhancedDependency dep,
                              final String value ) {
-        dep.setVersion( value );
+        dep.getDependency().setVersion( value );
     }
 }
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/WhiteListCell.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/WhiteListCell.java
@@ -29,6 +29,9 @@ import com.google.gwt.uibinder.client.UiRenderer;
 
 public class WhiteListCell extends AbstractCell<String> {
 
+    public static final String UPDATE = "update";
+    public static final String TOGGLE = "toggle";
+
     private static CellBinder cellRenderer = GWT.create( CellBinder.class );
 
     interface CellBinder extends UiRenderer {
@@ -64,11 +67,11 @@ public class WhiteListCell extends AbstractCell<String> {
 
     }
 
-    @UiHandler({ "addAll", "addNone" })
+    @UiHandler( {"addAll", "addNone"} )
     void onActionGotPressed( ClickEvent event,
                              Element parent,
                              ValueUpdater valueUpdater,
                              String value ) {
-        valueUpdater.update( "" );
+        valueUpdater.update( TOGGLE );
     }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/WhiteListCell.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/WhiteListCell.ui.xml
@@ -21,7 +21,7 @@
   <div>
     <span><ui:text from="{value}"/></span>
     <div class="btn-group pull-right">
-      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button ui:field="whiteListButton" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="fa fa-cog"></i>
       </button>
       <ul class="dropdown-menu">

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/validation/DependencyValidator.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/validation/DependencyValidator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.validation;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+
+public class DependencyValidator {
+
+    private String message = null;
+
+    private Dependency dependency;
+
+    public DependencyValidator( final Dependency dependency ) {
+        this.dependency = dependency;
+    }
+
+    public static String validateVersion( final String version ) {
+        if ( isNullOrEmpty( version ) ) {
+            return ProjectEditorResources.CONSTANTS.DependencyIsMissingAVersion();
+        } else {
+            return null;
+        }
+    }
+
+    public static String validateArtifactId( final String artifactId ) {
+        if ( isNullOrEmpty( artifactId ) ) {
+            return ProjectEditorResources.CONSTANTS.DependencyIsMissingAnArtifactId();
+        } else {
+            return null;
+        }
+    }
+
+    public static String validateGroupId( final String groupId ) {
+        if ( isNullOrEmpty( groupId ) ) {
+            return ProjectEditorResources.CONSTANTS.DependencyIsMissingAGroupId();
+        } else {
+            return null;
+        }
+    }
+
+    private static boolean isNullOrEmpty( final String value ) {
+        return value == null || value.isEmpty();
+    }
+
+    public boolean validate() {
+
+        if ( !validateGroupId()
+                || !validateArtifactId()
+                || !validateVersion() ) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public boolean validateVersion() {
+        message = validateVersion( dependency.getVersion() );
+        return message == null;
+    }
+
+    public boolean validateArtifactId() {
+        message = validateArtifactId( dependency.getArtifactId() );
+        return message == null;
+    }
+
+    public boolean validateGroupId() {
+        message = validateGroupId( dependency.getGroupId() );
+        return message == null;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.java
@@ -307,4 +307,12 @@ public interface ProjectEditorConstants
 
     String Select();
 
+    String DependencyIsMissingAVersion();
+
+    String DependencyIsMissingAnArtifactId();
+
+    String DependencyIsMissingAGroupId();
+
+    String Dependency();
+
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/resources/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/resources/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.properties
@@ -158,3 +158,7 @@ RepositoriesValidationExplanationL1=These Maven Repositories are used to check t
 RepositoriesValidationExplanationL2=They are obtained from the Project''s pom, the Project''s Distribution Management configuration and Maven''s global settings.
 RepositoryInclude=Include
 Select=Select
+DependencyIsMissingAVersion=Dependency is missing a version
+DependencyIsMissingAnArtifactId=Dependency is missing an artifact ID
+DependencyIsMissingAGroupId=Dependency is missing a group ID
+Dependency=Dependency

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/DependencyTestUtils.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/DependencyTestUtils.java
@@ -19,6 +19,8 @@ import java.util.Collection;
 
 import org.guvnor.common.services.project.model.Dependency;
 import org.guvnor.common.services.project.model.GAV;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
 
 import static org.junit.Assert.*;
 
@@ -44,11 +46,12 @@ public class DependencyTestUtils {
         return dependency;
     }
 
-    public static void assertContains( final Collection<Dependency> dependencies,
+    public static void assertContains( final EnhancedDependencies dependencies,
                                        final String groupID,
                                        final String artifactID,
                                        final String version ) {
-        for ( Dependency dependency : dependencies ) {
+        for ( EnhancedDependency enhancedDependency : dependencies ) {
+            Dependency dependency = enhancedDependency.getDependency();
             if ( areNullSafeEquals( artifactID, dependency.getArtifactId() )
                     && areNullSafeEquals( groupID, dependency.getGroupId() )
                     && areNullSafeEquals( version, dependency.getVersion() ) ) {
@@ -70,12 +73,13 @@ public class DependencyTestUtils {
         }
     }
 
-    public static Dependency assertContains( final Collection<Dependency> dependencies,
+    public static Dependency assertContains( final EnhancedDependencies dependencies,
                                              final String groupID,
                                              final String artifactID,
                                              final String version,
                                              final String scope ) {
-        for ( Dependency dependency : dependencies ) {
+        for ( EnhancedDependency enhancedDependency : dependencies ) {
+            Dependency dependency = enhancedDependency.getDependency();
             if ( areNullSafeEquals( dependency.getArtifactId(), artifactID )
                     && areNullSafeEquals( dependency.getGroupId(), groupID )
                     && areNullSafeEquals( dependency.getVersion(), version )

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyFieldUpdaterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyFieldUpdaterTest.java
@@ -16,16 +16,13 @@
 package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.guvnor.common.services.project.model.Dependency;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.DependencyFieldUpdater;
-import org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.DependencyGridViewImpl;
-import org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.WaterMarkEditTextCell;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
+import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
 import org.mockito.Mock;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(GwtMockitoTestRunner.class)
@@ -43,16 +40,17 @@ public class DependencyFieldUpdaterTest {
     public void setUp() throws Exception {
         fieldUpdater = spy( new DependencyFieldUpdater( cell,
                                                         redrawCommand ) {
-            @Override protected void setValue( Dependency dep,
-                                               String value ) {
-                // Going to use Group id for testing, doesn't really matter.
-                dep.setGroupId( value );
+            @Override
+            protected void reportXML() {
             }
 
-            @Override protected void reportXML() {
+            @Override
+            protected void setValue( EnhancedDependency dep,
+                                     String value ) {
             }
 
-            @Override protected void reportEmpty() {
+            @Override
+            protected void reportEmpty() {
 
             }
         } );
@@ -60,39 +58,43 @@ public class DependencyFieldUpdaterTest {
 
     @Test
     public void testValid() throws Exception {
-        Dependency dependency = new Dependency();
+        final NormalEnhancedDependency enhancedDependency = new NormalEnhancedDependency();
         fieldUpdater.update( 1,
-                             dependency,
+                             enhancedDependency,
                              "value" );
 
-        assertEquals( "value", dependency.getGroupId() );
+        verify( fieldUpdater ).setValue( enhancedDependency,
+                                         "value" );
+        verify( cell, never() ).clearViewData( anyObject() );
+    }
+
+    @Test
+    public void testNonValidDependencyClearsViewDataAndRefreshesView() throws Exception {
+        final NormalEnhancedDependency enhancedDependency = new NormalEnhancedDependency();
+        fieldUpdater.update( 1,
+                             enhancedDependency,
+                             "" );
+
+        verify( cell ).clearViewData( enhancedDependency );
+        verify( redrawCommand ).execute();
     }
 
     @Test
     public void testEmpty() throws Exception {
-        Dependency dependency = new Dependency();
-        dependency.setGroupId( "I'm here" );
         fieldUpdater.update( 1,
-                             dependency,
+                             new NormalEnhancedDependency(),
                              "" );
 
-        assertEquals( "I'm here", dependency.getGroupId() );
         verify( fieldUpdater ).reportEmpty();
-        verify( cell ).clearViewData( dependency );
-        verify( redrawCommand ).execute();
     }
 
     @Test
-    public void testXMLAsValue() throws Exception {
-        Dependency dependency = new Dependency();
-        dependency.setGroupId( "I'm here" );
-        fieldUpdater.update( 1,
-                             dependency,
+    public void testXMLAsValueThatIsNotValid() throws Exception {
+        fieldUpdater.update( 10,
+                             new NormalEnhancedDependency(),
                              "<something>" );
 
-        assertEquals( "I'm here", dependency.getGroupId() );
         verify( fieldUpdater ).reportXML();
-        verify( cell ).clearViewData( dependency );
-        verify( redrawCommand ).execute();
     }
+
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderLoadFailureTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderLoadFailureTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.GAV;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.dependencies.DependencyService;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class DependencyLoaderLoadFailureTest {
+
+    @Mock
+    private EnhancedDependenciesManager manager;
+
+    @Mock
+    private Caller dependencyServiceCaller;
+
+    @Mock
+    private DependencyService dependencyService;
+
+    private DependencyLoader dependencyLoader;
+
+    @Before
+    public void setUp() throws Exception {
+        dependencyLoader = new DependencyLoader( dependencyServiceCaller );
+        dependencyLoader.init( manager );
+
+        when( dependencyServiceCaller.call( any( RemoteCallback.class ),
+                                            any( ErrorCallback.class ) ) ).thenReturn( dependencyService );
+    }
+
+    @Test
+    public void testFailureOnLoad() throws Exception {
+
+        dependencyLoader.addToQueue( makeDependency( "org.junit", "junit", "1.0" ) );
+
+        dependencyLoader.load();
+
+        failLoad();
+
+        final EnhancedDependencies enhancedDependencies = getUpdatedEnhancedDependencies();
+
+        assertEquals( 1, enhancedDependencies.size() );
+        assertNotNull( enhancedDependencies.get( new GAV( "org.junit", "junit", "1.0" ) ) );
+    }
+
+    private void failLoad() {
+        ArgumentCaptor<ErrorCallback> errorCallbackArgumentCaptor = ArgumentCaptor.forClass( ErrorCallback.class );
+        verify( dependencyServiceCaller ).call( any( RemoteCallback.class ),
+                                                errorCallbackArgumentCaptor.capture() );
+
+        errorCallbackArgumentCaptor.getValue().error( null, null );
+    }
+
+    private Dependency makeDependency( final String groupId,
+                                       final String artifactId,
+                                       final String version ) {
+        final Dependency dependency = new Dependency();
+        dependency.setGroupId( groupId );
+        dependency.setArtifactId( artifactId );
+        dependency.setVersion( version );
+        return dependency;
+    }
+
+    private EnhancedDependencies getUpdatedEnhancedDependencies() {
+        ArgumentCaptor<EnhancedDependencies> argumentCaptor = ArgumentCaptor.forClass( EnhancedDependencies.class );
+
+        verify( manager ).onEnhancedDependenciesUpdated( argumentCaptor.capture() );
+
+        return argumentCaptor.getValue();
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.dependencies.DependencyService;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.CallerMock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class DependencyLoaderTest {
+
+    @Mock
+    private EnhancedDependenciesManager manager;
+
+    @Mock
+    private DependencyService dependencyService;
+
+    private DependencyLoader dependencyLoader;
+
+    @Before
+    public void setUp() throws Exception {
+
+        dependencyLoader = new DependencyLoader( new CallerMock<>( dependencyService ) );
+        dependencyLoader.init( manager );
+    }
+
+    @Test
+    public void testLoadEmptyQueue() throws Exception {
+        dependencyLoader.load();
+
+        final EnhancedDependencies enhancedDependencies = getUpdatedEnhancedDependencies();
+
+        assertTrue( enhancedDependencies.isEmpty() );
+    }
+
+    @Test
+    public void testAdd() throws Exception {
+
+        final EnhancedDependencies enhancedDependencies = new EnhancedDependencies();
+        when( dependencyService.loadEnhancedDependencies( anyCollection() ) ).thenReturn( enhancedDependencies );
+
+        dependencyLoader.addToQueue( makeDependency( "artifactId", "groupId", "1.0" ) );
+
+        dependencyLoader.load();
+
+        final EnhancedDependencies updatedEnhancedDependencies = getUpdatedEnhancedDependencies();
+        assertEquals( enhancedDependencies, updatedEnhancedDependencies );
+    }
+
+    private Dependency makeDependency( final String artifactId,
+                                       final String groupId,
+                                       final String version ) {
+        final Dependency dependency = new Dependency();
+        dependency.setArtifactId( artifactId );
+        dependency.setGroupId( groupId );
+        dependency.setVersion( version );
+        return dependency;
+    }
+
+    private EnhancedDependencies getUpdatedEnhancedDependencies() {
+        ArgumentCaptor<EnhancedDependencies> argumentCaptor = ArgumentCaptor.forClass( EnhancedDependencies.class );
+
+        verify( manager ).onEnhancedDependenciesUpdated( argumentCaptor.capture() );
+
+        return argumentCaptor.getValue();
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManagerResetTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManagerResetTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import java.util.HashSet;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.POM;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.callbacks.Callback;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class EnhancedDependenciesManagerResetTest {
+
+    @Mock
+    private DependencyLoader loader;
+
+    @InjectMocks
+    private EnhancedDependenciesManager manager;
+
+    @Test
+    public void testReset() throws Exception {
+
+        final Callback callback = init( makePOM( makeDependency() ) );
+
+        final EnhancedDependencies shownEnhancedDependencies = getEnhancedDependencies( callback );
+
+        assertEquals( 1, shownEnhancedDependencies.size() );
+
+        final Callback callback2 = init( makePOM() );
+
+        final EnhancedDependencies shownEnhancedDependencies2 = getEnhancedDependencies( callback2 );
+
+        assertEquals( 0, shownEnhancedDependencies2.size() );
+    }
+
+    private Callback init( final POM pom ) {
+        final Callback callback = mock( Callback.class );
+        manager.init( pom,
+                      callback );
+
+        final EnhancedDependencies enhancedDependencies = new EnhancedDependencies();
+        for ( Dependency dependency : pom.getDependencies() ) {
+            enhancedDependencies.add( new NormalEnhancedDependency( dependency,
+                                                                    new HashSet<String>() ) );
+        }
+
+        manager.onEnhancedDependenciesUpdated( enhancedDependencies );
+        return callback;
+    }
+
+
+    private Dependency makeDependency() {
+        final Dependency dependency = new Dependency();
+        dependency.setScope( "compile" );
+
+        return dependency;
+    }
+
+    private POM makePOM( final Dependency... dependencies ) {
+        final POM pom = new POM();
+
+        for ( Dependency dependency : dependencies ) {
+            pom.getDependencies().add( dependency );
+        }
+
+        return pom;
+    }
+
+    private EnhancedDependencies getEnhancedDependencies( final Callback<EnhancedDependencies> callback1 ) {
+        ArgumentCaptor<EnhancedDependencies> dependenciesArgumentCaptor = ArgumentCaptor.forClass( EnhancedDependencies.class );
+        verify( callback1 ).callback( dependenciesArgumentCaptor.capture() );
+        return dependenciesArgumentCaptor.getValue();
+    }
+
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManagerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManagerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import java.util.HashSet;
+
+import org.guvnor.common.services.project.model.Dependencies;
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.POM;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.callbacks.Callback;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class EnhancedDependenciesManagerTest {
+
+    @Mock
+    private DependencyLoader dependencyLoader;
+
+    @InjectMocks
+    private EnhancedDependenciesManager enhancedDependenciesManager;
+
+    @Mock
+    private Callback<EnhancedDependencies> callback;
+
+    private Dependencies originalSetOfDependencies;
+
+    @Before
+    public void setUp() throws Exception {
+        originalSetOfDependencies = new Dependencies();
+
+        final POM pom = new POM();
+        pom.setDependencies( originalSetOfDependencies );
+        enhancedDependenciesManager.init( pom,
+                                          callback );
+    }
+
+    @Test
+    public void testUpload() throws Exception {
+        enhancedDependenciesManager.update();
+
+        verify( dependencyLoader ).load();
+    }
+
+    @Test
+    public void testAdd() throws Exception {
+        final Dependency dependency = makeDependency( "artifactId", "groupId", "1.0" );
+
+        enhancedDependenciesManager.addNew( dependency );
+
+        verify( dependencyLoader ).load();
+        assertEquals( 1, originalSetOfDependencies.size() );
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        enhancedDependenciesManager.addNew( makeDependency( "artifactId", "groupId", "1.0" ) );
+
+        enhancedDependenciesManager.delete( new NormalEnhancedDependency( makeDependency( "artifactId", "groupId", "1.0" ),
+                                                                          new HashSet<String>() ) );
+
+        assertTrue( originalSetOfDependencies.isEmpty() );
+    }
+
+    private Dependency makeDependency( final String artifactId,
+                                       final String groupId,
+                                       final String version ) {
+        final Dependency dependency = new Dependency();
+        dependency.setArtifactId( artifactId );
+        dependency.setGroupId( groupId );
+        dependency.setVersion( version );
+        return dependency;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager_onEchancedDependenciesLoadedTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager_onEchancedDependenciesLoadedTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import java.util.HashSet;
+
+import org.guvnor.common.services.project.model.Dependencies;
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.POM;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
+import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.callbacks.Callback;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class EnhancedDependenciesManager_onEchancedDependenciesLoadedTest {
+
+    @Mock
+    private DependencyLoader dependencyLoader;
+
+    @InjectMocks
+    private EnhancedDependenciesManager enhancedDependenciesManager;
+
+    private Dependencies         originalSetOfDependencies;
+    private EnhancedDependencies shownDependencies;
+    private Dependency           junit;
+
+    @Before
+    public void setUp() throws Exception {
+        shownDependencies = null;
+        originalSetOfDependencies = new Dependencies();
+        junit = makeDependency( "org.junit", "junit", "1.0" );
+        originalSetOfDependencies.add( junit );
+        originalSetOfDependencies.add( makeDependency( "org.drools", "drools-core", "4.0" ) );
+
+        final POM pom = new POM();
+        pom.setDependencies( originalSetOfDependencies );
+        enhancedDependenciesManager.init( pom,
+                                          new Callback<EnhancedDependencies>() {
+                                              @Override
+                                              public void callback( final EnhancedDependencies result ) {
+                                                  shownDependencies = result;
+                                              }
+                                          } );
+    }
+
+    @Test
+    public void testShowEmpty() throws Exception {
+        originalSetOfDependencies.clear();
+        enhancedDependenciesManager.onEnhancedDependenciesUpdated( new EnhancedDependencies() );
+        assertNotNull( shownDependencies );
+    }
+
+    @Test
+    public void testAdd() throws Exception {
+        final Dependency dependency = makeDependency( "artifactId", "groupId", "1.0" );
+
+        enhancedDependenciesManager.addNew( dependency );
+
+        final EnhancedDependencies loadedEnhancedDependencies = new EnhancedDependencies();
+        loadedEnhancedDependencies.add( new NormalEnhancedDependency( dependency,
+                                                                      new HashSet<String>() ) );
+        enhancedDependenciesManager.onEnhancedDependenciesUpdated( loadedEnhancedDependencies );
+
+        assertEquals( 3, originalSetOfDependencies.size() );
+        assertTrue( originalSetOfDependencies.contains( dependency ) );
+
+        assertEquals( 1, shownDependencies.size() );
+        assertTrue( shownDependencies.asList().get( 0 ).getDependency().isGAVEqual( dependency ) );
+    }
+
+    @Test
+    public void testEditingEnhancedUpdatesOriginal() throws Exception {
+
+        final EnhancedDependencies loadedEnhancedDependencies = new EnhancedDependencies();
+        loadedEnhancedDependencies.add( new NormalEnhancedDependency( makeDependency( "org.junit", "junit", "1.0" ),
+                                                                      new HashSet<String>() ) );
+        enhancedDependenciesManager.onEnhancedDependenciesUpdated( loadedEnhancedDependencies );
+
+        final EnhancedDependency enhancedDependency = shownDependencies.asList().get( 0 );
+
+        enhancedDependency.getDependency().setArtifactId( "newId" );
+        assertEquals( "newId", junit.getArtifactId() );
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        enhancedDependenciesManager.delete( new NormalEnhancedDependency( makeDependency( "org.junit", "junit", "1.0" ),
+                                                                          new HashSet<String>() ) );
+
+        verify( dependencyLoader ).load();
+
+        // Queue is empty so loader returns with nothing.
+        enhancedDependenciesManager.onEnhancedDependenciesUpdated( new EnhancedDependencies() );
+
+        assertTrue( shownDependencies.isEmpty() );
+        assertFalse( originalSetOfDependencies.contains( junit ) );
+    }
+
+    private Dependency makeDependency( final String artifactId,
+                                       final String groupId,
+                                       final String version ) {
+        final Dependency dependency = new Dependency();
+        dependency.setArtifactId( artifactId );
+        dependency.setGroupId( groupId );
+        dependency.setVersion( version );
+        return dependency;
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.model.Dependency;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.screens.projecteditor.client.resources.i18n.ProjectEditorConstants;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.client.callbacks.Callback;
+
+import static org.mockito.Mockito.*;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class NewDependencyPopupTest {
+
+    @GwtMock
+    ProjectEditorResources resources;
+
+    @GwtMock
+    ProjectEditorConstants constants;
+
+    @Mock
+    private NewDependencyPopupView view;
+
+    @Mock
+    private Callback<Dependency> callback;
+
+    @Captor
+    private ArgumentCaptor<Dependency> dependencyArgumentCaptor;
+
+    private NewDependencyPopup newDependencyPopup;
+
+    @Before
+    public void setUp() throws Exception {
+        newDependencyPopup = new NewDependencyPopup( view );
+        newDependencyPopup.show( callback );
+    }
+
+    @Test
+    public void testClearOldValues() throws Exception {
+
+        verify( view ).clean();
+
+        newDependencyPopup.show( callback );
+
+        verify( view, times( 2 ) ).clean();
+    }
+
+    @Test
+    public void testSetPresenter() throws Exception {
+        verify( view ).setPresenter( newDependencyPopup );
+    }
+
+    @Test
+    public void testShowView() throws Exception {
+        verify( view ).show();
+    }
+
+    @Test
+    public void testFillValidDependency() throws Exception {
+        fillInValidGAV();
+
+        newDependencyPopup.onOkClicked();
+
+        verify( callback ).callback( any( Dependency.class ) );
+        verify( view ).hide();
+    }
+
+    @Test
+    public void testCloseIfDependencyValid() throws Exception {
+        fillInValidGAV();
+
+        newDependencyPopup.onOkClicked();
+
+        verify( view ).hide();
+    }
+
+    @Test
+    public void testValuesAreClearedWhenReopening() throws Exception {
+        fillInValidGAV();
+
+        newDependencyPopup.onArtifactIdChange( "artifactId" );
+
+        // reopen
+        newDependencyPopup.show( callback );
+
+        newDependencyPopup.onOkClicked();
+        verify( callback, never() ).callback( any( Dependency.class ) );
+    }
+
+    private void fillInValidGAV() {
+        newDependencyPopup.onGroupIdChange( "groupID" );
+        newDependencyPopup.onArtifactIdChange( "myArtifactID" );
+        newDependencyPopup.onVersionChange( "1.0" );
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupValidationTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/NewDependencyPopupValidationTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.model.Dependency;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.screens.projecteditor.client.resources.i18n.ProjectEditorConstants;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.client.callbacks.Callback;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class NewDependencyPopupValidationTest {
+
+    @GwtMock
+    ProjectEditorResources resources;
+
+    @GwtMock
+    ProjectEditorConstants constants;
+
+    @Mock
+    private NewDependencyPopupView view;
+
+    @Mock
+    private Callback<Dependency> callback;
+
+    @Captor
+    private ArgumentCaptor<Dependency> dependencyArgumentCaptor;
+
+    private NewDependencyPopup newDependencyPopup;
+
+    @Before
+    public void setUp() throws Exception {
+        newDependencyPopup = new NewDependencyPopup( view );
+        newDependencyPopup.show( callback );
+
+    }
+
+    @Test
+    public void testFillValidDependency() throws Exception {
+        fillInValidGAV();
+
+        final Dependency dependency = userClicksOk();
+
+        assertEquals( "groupID", dependency.getGroupId() );
+        assertEquals( "myArtifactID", dependency.getArtifactId() );
+        assertEquals( "1.0", dependency.getVersion() );
+    }
+
+    @Test
+    public void testCloseIfDependencyValid() throws Exception {
+        fillInValidGAV();
+
+        newDependencyPopup.onOkClicked();
+
+        verify( view ).hide();
+    }
+
+    @Test
+    public void testFillInValidDependency() throws Exception {
+        fillInValidGAV();
+        newDependencyPopup.onGroupIdChange( "" );
+
+        newDependencyPopup.onOkClicked();
+
+        verify( callback, never() ).callback( any( Dependency.class ) );
+        verify( view, never() ).hide();
+    }
+
+    @Test
+    public void testFillInValidGroupIdDependency() throws Exception {
+        newDependencyPopup.onArtifactIdChange( "test" );
+        newDependencyPopup.onVersionChange( "1.0" );
+
+        newDependencyPopup.onOkClicked();
+
+        verify( view ).setGroupIdValidationState( ValidationState.ERROR );
+    }
+
+    @Test
+    public void testFillInValidArtifactIdDependency() throws Exception {
+        newDependencyPopup.onGroupIdChange( "org.test" );
+        newDependencyPopup.onVersionChange( "1.0" );
+
+        newDependencyPopup.onOkClicked();
+
+        verify( view ).setArtifactIdValidationState( ValidationState.ERROR );
+    }
+
+    @Test
+    public void testFillInValidVersionDependency() throws Exception {
+        newDependencyPopup.onGroupIdChange( "org.test" );
+        newDependencyPopup.onArtifactIdChange( "test" );
+
+        newDependencyPopup.onOkClicked();
+
+        verify( view ).setVersionValidationState( ValidationState.ERROR );
+    }
+
+    @Test
+    public void testInValidGroupId() throws Exception {
+        newDependencyPopup.onGroupIdChange( "" );
+
+        verify( view ).invalidGroupId( "DependencyIsMissingAGroupId" );
+        verify( view ).setGroupIdValidationState( ValidationState.ERROR );
+    }
+
+    @Test
+    public void testValidGroupId() throws Exception {
+        newDependencyPopup.onGroupIdChange( "org.test" );
+
+        verify( view ).invalidGroupId( "" );
+        verify( view ).setGroupIdValidationState( ValidationState.SUCCESS );
+    }
+
+    @Test
+    public void testInValidArtifactId() throws Exception {
+        newDependencyPopup.onArtifactIdChange( "" );
+
+        verify( view ).invalidArtifactId( "DependencyIsMissingAnArtifactId" );
+        verify( view ).setArtifactIdValidationState( ValidationState.ERROR );
+    }
+
+    @Test
+    public void testValidArtifactId() throws Exception {
+        newDependencyPopup.onArtifactIdChange( "artifact" );
+
+        verify( view ).invalidArtifactId( "" );
+        verify( view ).setArtifactIdValidationState( ValidationState.SUCCESS );
+    }
+
+    @Test
+    public void testInValidVersion() throws Exception {
+        newDependencyPopup.onVersionChange( "" );
+
+        verify( view ).invalidVersion( "DependencyIsMissingAVersion" );
+        verify( view ).setVersionValidationState( ValidationState.ERROR );
+    }
+
+    @Test
+    public void testValidVersion() throws Exception {
+        newDependencyPopup.onVersionChange( "1.0" );
+
+        verify( view ).invalidVersion( "" );
+        verify( view ).setVersionValidationState( ValidationState.SUCCESS );
+    }
+
+
+    private Dependency userClicksOk() {
+        newDependencyPopup.onOkClicked();
+        verify( callback ).callback( dependencyArgumentCaptor.capture() );
+        return dependencyArgumentCaptor.getValue();
+    }
+
+    private void fillInValidGAV() {
+        newDependencyPopup.onGroupIdChange( "groupID" );
+        newDependencyPopup.onArtifactIdChange( "myArtifactID" );
+        newDependencyPopup.onVersionChange( "1.0" );
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/RemoveColumnTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/RemoveColumnTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
 
+import java.util.HashSet;
+
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -23,6 +25,9 @@ import org.guvnor.common.services.project.model.Dependency;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.dependencies.EnhancedDependency;
+import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
+import org.kie.workbench.common.services.shared.dependencies.TransitiveEnhancedDependency;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -41,17 +46,10 @@ public class RemoveColumnTest {
     }
 
     @Test
-    public void testRenderScopeNull() throws Exception {
-
-        render( null );
-
-        assertFalse( safeHtmlBuilder.toSafeHtml().asString().contains( " disabled=\"disabled\"" ) );
-    }
-
-    @Test
     public void testRenderScopeCompile() throws Exception {
 
-        render( "compile" );
+        render( new NormalEnhancedDependency( new Dependency(),
+                                              new HashSet<String>() ) );
 
         assertFalse( safeHtmlBuilder.toSafeHtml().asString().contains( " disabled=\"disabled\"" ) );
     }
@@ -59,14 +57,14 @@ public class RemoveColumnTest {
     @Test
     public void testRenderScopeTransitive() throws Exception {
 
-        render( "transitive" );
+        render( new TransitiveEnhancedDependency( new Dependency(),
+                                                  new HashSet<String>() ) );
 
         assertTrue( safeHtmlBuilder.toSafeHtml().asString().contains( " disabled=\"disabled\"" ) );
     }
 
-    private void render( final String scope ) {
-        final Dependency dependency = new Dependency();
-        dependency.setScope( scope );
+    private void render( final EnhancedDependency dependency ) {
+
         removeColumn.render( mock( Cell.Context.class ),
                              dependency,
                              safeHtmlBuilder );

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/validation/DependencyValidatorTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/validation/DependencyValidatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.validation;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.GAV;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
+import org.kie.workbench.common.screens.projecteditor.client.resources.i18n.ProjectEditorConstants;
+
+import static org.junit.Assert.*;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class DependencyValidatorTest {
+
+    @GwtMock
+    ProjectEditorResources resources;
+
+    @GwtMock
+    ProjectEditorConstants constants;
+
+    @Test
+    public void testValid() throws Exception {
+        DependencyValidator dependencyValidator = new DependencyValidator( new Dependency( new GAV( "groupId",
+                                                                                                    "artifactId",
+                                                                                                    "1.0" ) ) );
+
+        assertTrue( dependencyValidator.validate() );
+    }
+
+    @Test
+    public void testGroupId() throws Exception {
+        DependencyValidator dependencyValidator = new DependencyValidator( new Dependency( new GAV( null,
+                                                                                                    "artifactId",
+                                                                                                    "1.0" ) ) );
+        assertFalse( dependencyValidator.validate() );
+
+        assertEquals( "DependencyIsMissingAGroupId", dependencyValidator.getMessage() );
+    }
+
+    @Test
+    public void testArtifactId() throws Exception {
+        DependencyValidator dependencyValidator = new DependencyValidator( new Dependency( new GAV( "groupId",
+                                                                                                    null,
+                                                                                                    "1.0" ) ) );
+        assertFalse( dependencyValidator.validate() );
+
+        assertEquals( "DependencyIsMissingAnArtifactId", dependencyValidator.getMessage() );
+    }
+
+    @Test
+    public void testVersion() throws Exception {
+        DependencyValidator dependencyValidator = new DependencyValidator( new Dependency( new GAV( "groupId",
+                                                                                                    "artifactId",
+                                                                                                    null ) ) );
+        assertFalse( dependencyValidator.validate() );
+
+        assertEquals( "DependencyIsMissingAVersion", dependencyValidator.getMessage() );
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependencies.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependencies.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.shared.dependencies;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+import org.guvnor.common.services.project.model.GAV;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class EnhancedDependencies
+        implements Iterable<EnhancedDependency> {
+
+    private final HashMap<GAV, EnhancedDependency> enhancedDependencies = new HashMap<>();
+
+    public EnhancedDependencies() {
+    }
+
+    public EnhancedDependencies( final List<EnhancedDependency> enhancedDependencies ) {
+        for ( final EnhancedDependency enhancedDependency : enhancedDependencies ) {
+            add( enhancedDependency );
+        }
+    }
+
+    public void add( final EnhancedDependency enhancedDependency ) {
+        this.enhancedDependencies.put( enhancedDependency.getDependency(),
+                                       enhancedDependency );
+    }
+
+    public boolean remove( final EnhancedDependency enhancedDependency ) {
+        final EnhancedDependency remove = enhancedDependencies.remove( enhancedDependency.getDependency() );
+        return remove != null;
+    }
+
+    public boolean isEmpty() {
+        return enhancedDependencies.isEmpty();
+    }
+
+    public boolean contains( final EnhancedDependency enhancedDependency ) {
+        return enhancedDependencies.containsKey( enhancedDependency.getDependency() );
+    }
+
+    public void update( final EnhancedDependency enhancedDependency ) {
+        remove( enhancedDependency );
+        add( enhancedDependency );
+    }
+
+    public EnhancedDependency get( final GAV gav ) {
+        return enhancedDependencies.get( gav );
+    }
+
+    @Override
+    public Iterator<EnhancedDependency> iterator() {
+        return enhancedDependencies.values().iterator();
+    }
+
+    /**
+     * @return A list of enhanced dependencies including the top level "normal" dependencies and
+     * the transient dependencies for the "normal" dependencies.
+     * If a dependency is both declared in the pom and transient the one declared in the pom in included.
+     */
+    public List<? extends EnhancedDependency> asList() {
+        final ArrayList<EnhancedDependency> result = new ArrayList<>( enhancedDependencies.values() );
+
+        for ( final EnhancedDependency enhancedDependency : enhancedDependencies.values() ) {
+            if ( enhancedDependency instanceof NormalEnhancedDependency ) {
+                final NormalEnhancedDependency normalEnhancedDependency = ( NormalEnhancedDependency ) enhancedDependency;
+
+                for ( final EnhancedDependency transitiveDependency : normalEnhancedDependency.getTransitiveDependencies().asList() ) {
+                    if ( !enhancedDependencies.containsKey( transitiveDependency.getDependency() ) ) {
+                        result.add( transitiveDependency );
+                    }
+                }
+            }
+        }
+
+        return Collections.unmodifiableList( result );
+    }
+
+    public int size() {
+        return enhancedDependencies.size();
+    }
+
+    public void addAll( final Collection<EnhancedDependency> transitiveDependencies ) {
+        for ( final EnhancedDependency transitiveDependency : transitiveDependencies ) {
+            add( transitiveDependency );
+        }
+
+    }
+
+    public void clear() {
+        enhancedDependencies.clear();
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependency.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependency.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.shared.dependencies;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.guvnor.common.services.project.model.Dependency;
+
+public abstract class EnhancedDependency {
+
+    protected Dependency dependency;
+
+    protected final Set<String> packageNames = new HashSet<>();
+
+    public EnhancedDependency() {
+    }
+
+    public EnhancedDependency( final Dependency dependency,
+                               final Set<String> packageNames ) {
+        this.dependency = dependency;
+        this.packageNames.addAll( packageNames );
+    }
+
+    public Dependency getDependency() {
+        return dependency;
+    }
+
+    public Set<String> getPackages() {
+        return packageNames;
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/NormalEnhancedDependency.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/NormalEnhancedDependency.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.shared.dependencies;
+
+import java.util.Set;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class NormalEnhancedDependency
+        extends EnhancedDependency {
+
+    private final EnhancedDependencies transitiveDependencies = new EnhancedDependencies();
+
+    public NormalEnhancedDependency() {
+    }
+
+    public NormalEnhancedDependency( final Dependency dependency,
+                                     final Set<String> packageNames ) {
+        super( dependency,
+               packageNames );
+    }
+
+    public void setDependency( final Dependency dependency ) {
+        this.dependency = dependency;
+    }
+
+    public EnhancedDependencies getTransitiveDependencies() {
+        return transitiveDependencies;
+    }
+
+    public void addTransitiveDependency( final TransitiveEnhancedDependency transitiveEnhancedDependency ) {
+        this.transitiveDependencies.add( transitiveEnhancedDependency );
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/TransitiveEnhancedDependency.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/dependencies/TransitiveEnhancedDependency.java
@@ -1,36 +1,37 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
+
 package org.kie.workbench.common.services.shared.dependencies;
 
-import java.util.Collection;
 import java.util.Set;
 
 import org.guvnor.common.services.project.model.Dependency;
-import org.guvnor.common.services.project.model.GAV;
-import org.jboss.errai.bus.server.annotations.Remote;
+import org.jboss.errai.common.client.api.annotations.Portable;
 
-@Remote
-public interface DependencyService {
+@Portable
+public class TransitiveEnhancedDependency
+        extends EnhancedDependency {
 
-    Collection<Dependency> loadDependencies( final Collection<GAV> gavs );
+    public TransitiveEnhancedDependency() {
+    }
 
-    Collection<Dependency> loadDependencies( final GAV gav);
+    public TransitiveEnhancedDependency( final Dependency transitiveDependency,
+                                         final Set<String> packageNames ) {
 
-    Set<String> loadPackageNames( final GAV gav );
-
-    EnhancedDependencies loadEnhancedDependencies( final Collection<Dependency> dependencies );
-
-
+        super( transitiveDependency,
+               packageNames );
+    }
 }

--- a/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependenciesAsListTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependenciesAsListTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.shared.dependencies;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.GAV;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EnhancedDependenciesAsListTest {
+
+    private EnhancedDependencies         enhancedDependencies;
+    private NormalEnhancedDependency     droolsCoreNormalDependency;
+    private TransitiveEnhancedDependency xstreamTransitiveDependency;
+    private NormalEnhancedDependency     xstreamNormalDependency;
+    private TransitiveEnhancedDependency droolsApiTransitiveDependency1;
+    private NormalEnhancedDependency     droolsCompilerNormalDependency;
+    private TransitiveEnhancedDependency droolsApiTransitiveDependency2;
+
+    @Before
+    public void setUp() throws Exception {
+        enhancedDependencies = new EnhancedDependencies();
+
+        addDroolsCore();
+        addXStream();
+        addDroolsCompiler();
+    }
+
+    public void addDroolsCompiler() {
+        droolsCompilerNormalDependency = new NormalEnhancedDependency( new Dependency( new GAV( "org.drools:drools-compiler:1.3" ) ),
+                                                                       new HashSet<>() );
+
+        droolsApiTransitiveDependency2 = new TransitiveEnhancedDependency( new Dependency( new GAV( "org.drools:drools-api:1.0" ) ),
+                                                                           new HashSet<>() );
+        droolsCompilerNormalDependency.addTransitiveDependency( droolsApiTransitiveDependency2 );
+        enhancedDependencies.add( droolsCompilerNormalDependency );
+    }
+
+    private void addXStream() {
+        xstreamNormalDependency = new NormalEnhancedDependency( new Dependency( new GAV( "org.xstream:xstream:1.0" ) ),
+                                                                new HashSet<>() );
+        enhancedDependencies.add( xstreamNormalDependency );
+    }
+
+    private void addDroolsCore() {
+        droolsCoreNormalDependency = new NormalEnhancedDependency( new Dependency( new GAV( "org.drools:drools-core:1.3" ) ),
+                                                                   new HashSet<>() );
+
+        xstreamTransitiveDependency = new TransitiveEnhancedDependency( new Dependency( new GAV( "org.xstream:xstream:1.0" ) ),
+                                                                        new HashSet<>() );
+        droolsApiTransitiveDependency1 = new TransitiveEnhancedDependency( new Dependency( new GAV( "org.drools:drools-api:1.0" ) ),
+                                                                           new HashSet<>() );
+
+        droolsCoreNormalDependency.addTransitiveDependency( xstreamTransitiveDependency );
+        enhancedDependencies.add( droolsCoreNormalDependency );
+    }
+
+    @Test
+    public void testSize() throws Exception {
+        assertEquals( 4, this.enhancedDependencies.asList().size() );
+    }
+
+    @Test
+    public void testDefaultContent() throws Exception {
+        final List<? extends EnhancedDependency> enhancedDependencies = this.enhancedDependencies.asList();
+
+        assertTrue( enhancedDependencies.contains( droolsCoreNormalDependency ) );
+        assertTrue( enhancedDependencies.contains( droolsApiTransitiveDependency1 )
+                            || enhancedDependencies.contains( droolsApiTransitiveDependency2 ) );
+        assertFalse( enhancedDependencies.contains( xstreamTransitiveDependency ) );
+        assertTrue( enhancedDependencies.contains( xstreamNormalDependency ) );
+        assertTrue( enhancedDependencies.contains( droolsCompilerNormalDependency ) );
+    }
+
+    @Test( expected = UnsupportedOperationException.class )
+    public void testUnModifiable() throws Exception {
+        this.enhancedDependencies.asList().clear();
+    }
+
+    @Test
+    public void testRemoveNormalXStream() throws Exception {
+        this.enhancedDependencies.remove( xstreamNormalDependency );
+
+        final List<? extends EnhancedDependency> enhancedDependencies = this.enhancedDependencies.asList();
+
+        assertTrue( enhancedDependencies.contains( xstreamTransitiveDependency ) );
+        assertFalse( enhancedDependencies.contains( xstreamNormalDependency ) );
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependenciesTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/dependencies/EnhancedDependenciesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.shared.dependencies;
+
+import java.util.HashSet;
+
+import org.guvnor.common.services.project.model.Dependency;
+import org.guvnor.common.services.project.model.GAV;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EnhancedDependenciesTest {
+
+    private EnhancedDependencies enhancedDependencies;
+
+    @Before
+    public void setUp() throws Exception {
+        enhancedDependencies = new EnhancedDependencies();
+        final NormalEnhancedDependency enhancedDependency = new NormalEnhancedDependency( new Dependency( new GAV( "org.hamcrest",
+                                                                                                                   "hamcrest-core",
+                                                                                                                   "1.3" ) ),
+                                                                                          new HashSet<>() );
+        enhancedDependency.addTransitiveDependency( new TransitiveEnhancedDependency( new Dependency( new GAV( "hi:something:1.0" ) ),
+                                                                                      new HashSet<String>() ) );
+        enhancedDependencies.add( enhancedDependency );
+    }
+
+    @Test
+    public void testRemoveRemovesByDependencyGAV() throws Exception {
+
+        assertTrue( enhancedDependencies.remove( new NormalEnhancedDependency( new Dependency( new GAV( "org.hamcrest",
+                                                                                                        "hamcrest-core",
+                                                                                                        "1.3" ) ),
+                                                                               new HashSet<String>() ) ) );
+
+        assertTrue( enhancedDependencies.isEmpty() );
+    }
+
+    @Test
+    public void testContainsChecksByGAV() throws Exception {
+        assertTrue( enhancedDependencies.contains( new NormalEnhancedDependency( new Dependency( new GAV( "org.hamcrest",
+                                                                                                          "hamcrest-core",
+                                                                                                          "1.3" ) ),
+                                                                                 new HashSet<String>() ) ) );
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+        enhancedDependencies.update( new NormalEnhancedDependency( new Dependency( new GAV( "org.hamcrest",
+                                                                                            "hamcrest-core",
+                                                                                            "1.3" ) ),
+                                                                   new HashSet<String>() ) );
+        NormalEnhancedDependency enhancedDependency = ( NormalEnhancedDependency ) enhancedDependencies.get( new GAV( "org.hamcrest",
+                                                                                                                      "hamcrest-core",
+                                                                                                                      "1.3" ) );
+        assertTrue( enhancedDependency.getTransitiveDependencies().isEmpty() );
+    }
+
+    @Test
+    public void testClear() throws Exception {
+        enhancedDependencies.clear();
+
+        assertTrue( enhancedDependencies.isEmpty() );
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/whitelist/WhiteListTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/test/java/org/kie/workbench/common/services/shared/whitelist/WhiteListTest.java
@@ -18,7 +18,9 @@ package org.kie.workbench.common.services.shared.whitelist;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
+import org.guvnor.common.services.project.model.POM;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/dependencies/DependencyServiceImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/dependencies/DependencyServiceImplTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.aether.artifact.Artifact;
@@ -187,53 +186,15 @@ public class DependencyServiceImplTest {
 
     @Test
     public void testFillDependenciesWithPackageNames() throws Exception {
-        List<Dependency> dependencyCollection = new ArrayList<Dependency>();
-        dependencyCollection.add( new Dependency( new GAV( "junit",
-                                                           "junit",
-                                                           "4.11" ) ) );
-        dependencyCollection.add( new Dependency( new GAV( "org.hamcrest",
-                                                           "hamcrest-core",
-                                                           "1.3" ) ) );
+        final Set<String> packageNames = service.loadPackageNames( new GAV( "junit",
+                                                                            "junit",
+                                                                            "4.11" ) );
 
-        final Collection<Dependency> dependencies = service.loadDependenciesWithPackageNames( dependencyCollection );
+        assertEquals( 2, packageNames.size() );
+        assertTrue( packageNames.contains( "org.junit.rules" ) );
+        assertTrue( packageNames.contains( "org.junit.matchers" ) );
 
-        assertEquals( 2, dependencies.size() );
-
-        boolean foundJunit = false;
-        boolean foundHamcrest = false;
-
-        for ( Dependency dependency : dependencies ) {
-            final String gav = dependency.toString();
-
-            if ( gav.equals( "junit:junit:4.11" ) ) {
-                assertEquals( 2, dependency.getPackages().size() );
-
-                assertTrue( dependency.getPackages().contains( "org.junit.rules" ) );
-                assertTrue( dependency.getPackages().contains( "org.junit.matchers" ) );
-
-                assertFalse( dependency.getPackages().contains( "org.hamcrest" ) );
-                assertFalse( dependency.getPackages().contains( "org.hamcrest.core" ) );
-
-                foundJunit = true;
-
-            } else if ( gav.equals( "org.hamcrest:hamcrest-core:1.3" ) ) {
-                assertEquals( 2, dependency.getPackages().size() );
-
-                assertTrue( dependency.getPackages().contains( "org.hamcrest" ) );
-                assertTrue( dependency.getPackages().contains( "org.hamcrest.core" ) );
-
-                assertFalse( dependency.getPackages().contains( "org.junit.rules" ) );
-                assertFalse( dependency.getPackages().contains( "org.junit.matchers" ) );
-
-                foundHamcrest = true;
-            }
-        }
-
-        assertTrue( foundJunit );
-        assertTrue( foundHamcrest );
     }
-
-    // TODO: Dependency does not exist
 
     private DependencyDescriptor makeDependencyDescriptor( final String groupId,
                                                            final String artifactId,


### PR DESCRIPTION
The issue was that the model presentented in the dependency grid was not the same as the one in the POM model class. This was because we list both the dependencies from the pom and the transient dependencies of these dependencies in the grid. Because of this updates or adding new dependencies was not working correctly. The fix for this is I made `EnchancedDependencies` to be shown on the grid, these are both "normal" from the pom's deps and transient deps of these deps. Then `EnhancedDependenciesManager` is responsible for keeping the grid and the pom model in sync.

`EnchancedDependencies` also includes the packageNames the dependency contains. These are used by the editor's white list features. 

Since the `EnhanceDependencyManager` is now responsible for synching. I added a `NewDependencyPopup` for the grid. Before we would hit "new" and this added an empty line in to the grid. Now to prevent the user from adding 10 empty lines (or partially filled in lines) and hitting save, the user has to first will in the popup form with valid GAV.  

https://github.com/droolsjbpm/guvnor/pull/292