### PR TITLE
Update CheckboxCellImpl package (moved to uberfire-widgets-table).

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/pom.xml
@@ -58,6 +58,10 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-commons</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-table</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-client/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-table</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>
     <dependency>

--- a/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-client/src/main/java/org/kie/workbench/common/screens/search/client/widgets/SearchResultTable.java
+++ b/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-client/src/main/java/org/kie/workbench/common/screens/search/client/widgets/SearchResultTable.java
@@ -37,7 +37,7 @@ import org.kie.workbench.common.screens.search.service.SearchService;
 import org.kie.workbench.common.widgets.client.tables.AbstractPathPagedTable;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.client.workbench.type.ClientTypeRegistry;
-import org.uberfire.ext.widgets.common.client.common.CheckboxCellImpl;
+import org.uberfire.ext.widgets.table.client.CheckboxCellImpl;
 import org.uberfire.ext.widgets.common.client.tables.ComparableImageResource;
 import org.uberfire.ext.widgets.common.client.tables.ComparableImageResourceCell;
 import org.uberfire.ext.widgets.common.client.tables.TitledTextCell;

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>uberfire-widgets-commons</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-table</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-api</artifactId>
     </dependency>

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/AbstractCellFactory.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/AbstractCellFactory.java
@@ -34,7 +34,7 @@ import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.PopupN
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.PopupNumericLongEditCell;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.PopupNumericShortEditCell;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.PopupTextEditCell;
-import org.uberfire.ext.widgets.common.client.common.CheckboxCellImpl;
+import org.uberfire.ext.widgets.table.client.CheckboxCellImpl;
 
 /**
  * A Factory to provide the Cells.


### PR DESCRIPTION
Update usage of CheckboxCellImpl (moved in [this PR](https://github.com/uberfire/uberfire-extensions/pull/274)) and add uberfire-widgets-table dependency to appease the maven enforcer plugin.