### PR TITLE
Render items from BuildOptionExtensions in (not beside) dropdown list

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenter.java
@@ -233,7 +233,7 @@ public class ProjectScreenPresenter
                 update();
             }
         } );
-        this.buildOptions = view.getBuildOptionsButton();
+        this.buildOptions = view.getBuildButtons();
 
         makeMenuBar();
 
@@ -255,15 +255,16 @@ public class ProjectScreenPresenter
     }
 
     private void configureBuildExtensions( final Project project,
-                                           final ButtonGroup buildDropdownButton ) {
+                                           final ButtonGroup buildButtonGroup ) {
         cleanExtensions();
+        final DropDownMenu buildDropdown = getDropdown( buildButtonGroup );
 
-        if ( project == null ) {
+        if ( project == null || buildDropdown == null ) {
             buildExtensions = null;
             return;
         }
 
-        Pair<Collection<BuildOptionExtension>, Collection<BuildOptionExtension>> pair = getBuildExtensions();
+        final Pair<Collection<BuildOptionExtension>, Collection<BuildOptionExtension>> pair = getBuildExtensions();
         Collection<BuildOptionExtension> allExtensions = pair.getK1();
         Collection<BuildOptionExtension> dependentScopedExtensions = pair.getK2();
 
@@ -274,12 +275,23 @@ public class ProjectScreenPresenter
                 if ( option instanceof DropDownHeader ||
                         option instanceof AnchorListItem ) {
                     buildExtensions.add( option );
-                    buildDropdownButton.add( option );
+                    buildDropdown.add( option );
                 }
             }
         }
 
         destroyExtensions( dependentScopedExtensions );
+    }
+
+    private DropDownMenu getDropdown( final ButtonGroup buildButtonGroup ) {
+        for (int i = 0; i < buildButtonGroup.getWidgetCount(); i++) {
+            final Widget widget = buildButtonGroup.getWidget( i );
+            if ( widget instanceof DropDownMenu ) {
+                return (DropDownMenu) widget;
+            }
+        }
+
+        return null;
     }
 
     private void cleanExtensions() {

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenView.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenView.java
@@ -131,7 +131,7 @@ public interface ProjectScreenView
 
     void showABuildIsAlreadyRunning();
 
-    ButtonGroup getBuildOptionsButton();
+    ButtonGroup getBuildButtons();
 
     void setDeployToRuntimeSetting( Boolean supports );
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenViewImpl.java
@@ -386,7 +386,7 @@ public class ProjectScreenViewImpl
     }
 
     @Override
-    public ButtonGroup getBuildOptionsButton() {
+    public ButtonGroup getBuildButtons() {
         return new ButtonGroup() {{
             add( new Button( ProjectEditorResources.CONSTANTS.Build() ) {{
                 setSize( ButtonSize.SMALL );

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTest.java
@@ -134,7 +134,7 @@ public class ProjectScreenPresenterTest {
         ApplicationPreferences.setUp( new HashMap<String, String>() );
 
         //The BuildOptions widget is manipulated in the Presenter so we need some nasty mocking
-        when( view.getBuildOptionsButton() ).thenReturn( buildOptions );
+        when( view.getBuildButtons() ).thenReturn( buildOptions );
         when( buildOptions.getWidget( eq( 0 ) ) ).thenReturn( buildOptionsButton1 );
         when( buildOptions.getWidget( eq( 1 ) ) ).thenReturn( buildOptionsMenu );
         when( buildOptionsMenu.getWidget( eq( 0 ) ) ).thenReturn( buildOptionsMenuButton1 );


### PR DESCRIPTION
This PR fixes the BuildOptionExtension feature that allows LiveSpark to add a custom button in the build drop-down list in the project authoring screen. Without this PR, the custom build button added by LiveSpark is rendered as a hyper-link beside the build drop-down list.