### PR TITLE
[6.3.x] BZ-1324141 - ServerImpl cannot be cast to KieServerInstance after mig…

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/ServerImplMigrationTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/test/java/org/kie/workbench/common/screens/server/management/backend/ServerImplMigrationTest.java
@@ -29,7 +29,7 @@ import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -45,7 +45,7 @@ public class ServerImplMigrationTest {
     public void testMigration() {
 
         String migrateServerXml = "<org.kie.server.controller.api.model.KieServerInstance>\n" +
-                "  <identifier>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</identifier>\n" +
+                "  <identifier>test</identifier>\n" +
                 "  <name>test</name>\n" +
                 "  <version>6.2.0.Final</version>\n" +
                 "  <managedInstances>\n" +
@@ -73,8 +73,8 @@ public class ServerImplMigrationTest {
         String serverImplXml = "<org.kie.workbench.common.screens.server.management.model.impl.ServerRefImpl>\n" +
                 "  <id>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</id>\n" +
                 "  <name>test</name>\n" +
-                "  <username>maciek</username>\n" +
-                "  <password>maciek@pwd1</password>\n" +
+                "  <username>user</username>\n" +
+                "  <password>password</password>\n" +
                 "  <status>LOADING</status>\n" +
                 "  <connectionType>REMOTE</connectionType>\n" +
                 "  <properties>\n" +
@@ -118,9 +118,184 @@ public class ServerImplMigrationTest {
         Path path = Mockito.mock(Path.class);
         when(path.toString()).thenReturn("test-server");
 
-        storage.migrate(path);
+        Path migratedPath = storage.migrate(path);
+        assertNotNull(migratedPath);
 
         verify(ioService, times( 1 )).delete(any(Path.class));
+        verify(ioService, times( 1 )).write(any(Path.class), anyString());
+
+        assertEquals(1, migrated.size());
+        assertEquals(migrateServerXml, migrated.get(0));
+    }
+
+    @Test
+    public void testMigrationServerNoName() {
+
+        String migrateServerXml = "<org.kie.server.controller.api.model.KieServerInstance>\n" +
+                "  <identifier>localhost</identifier>\n" +
+                "  <name></name>\n" +
+                "  <version>6.2.0.Final</version>\n" +
+                "  <managedInstances>\n" +
+                "    <org.kie.server.controller.api.model.KieServerInstanceInfo>\n" +
+                "      <location>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</location>\n" +
+                "      <status>DOWN</status>\n" +
+                "    </org.kie.server.controller.api.model.KieServerInstanceInfo>\n" +
+                "  </managedInstances>\n" +
+                "  <status>DOWN</status>\n" +
+                "  <kieServerSetup>\n" +
+                "    <containers>\n" +
+                "      <org.kie.server.api.model.KieContainerResource>\n" +
+                "        <containerId>mortgages</containerId>\n" +
+                "        <releaseId>\n" +
+                "          <groupId>mortgages</groupId>\n" +
+                "          <artifactId>mortgages</artifactId>\n" +
+                "          <version>0.0.1</version>\n" +
+                "        </releaseId>\n" +
+                "        <status>STOPPED</status>\n" +
+                "      </org.kie.server.api.model.KieContainerResource>\n" +
+                "    </containers>\n" +
+                "  </kieServerSetup>\n" +
+                "</org.kie.server.controller.api.model.KieServerInstance>";
+
+        String serverImplXml = "<org.kie.workbench.common.screens.server.management.model.impl.ServerRefImpl>\n" +
+                "  <id>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</id>\n" +
+                "  <name></name>\n" +
+                "  <username>user</username>\n" +
+                "  <password>password</password>\n" +
+                "  <status>LOADING</status>\n" +
+                "  <connectionType>REMOTE</connectionType>\n" +
+                "  <properties>\n" +
+                "    <entry>\n" +
+                "      <string>version</string>\n" +
+                "      <string>6.2.0.Final</string>\n" +
+                "    </entry>\n" +
+                "  </properties>\n" +
+                "  <containersRef>\n" +
+                "    <entry>\n" +
+                "      <string>mortgages</string>\n" +
+                "      <org.kie.workbench.common.screens.server.management.model.impl.ContainerRefImpl>\n" +
+                "        <serverId>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</serverId>\n" +
+                "        <id>mortgages</id>\n" +
+                "        <status>STOPPED</status>\n" +
+                "        <releaseId>\n" +
+                "          <groupId>mortgages</groupId>\n" +
+                "          <artifactId>mortgages</artifactId>\n" +
+                "          <version>0.0.1</version>\n" +
+                "        </releaseId>\n" +
+                "      </org.kie.workbench.common.screens.server.management.model.impl.ContainerRefImpl>\n" +
+                "    </entry>\n" +
+                "  </containersRef>\n" +
+                "</org.kie.workbench.common.screens.server.management.model.impl.ServerRefImpl>";
+
+        when(ioService.readAllString(any(Path.class))).thenReturn(serverImplXml);
+        when(fileSystem.getPath(anyString(), anyString(), anyString())).thenReturn(Mockito.mock(Path.class));
+
+        final List<String> migrated = new ArrayList<String>();
+
+        when(ioService.write(any(Path.class), anyString())).thenAnswer(new Answer() {
+            public Object answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                migrated.add((String)args[1]);
+                return null;
+            }
+        });
+
+        VFSKieServerControllerStorage storage = new VFSKieServerControllerStorage(ioService, fileSystem);
+
+        Path path = Mockito.mock(Path.class);
+        when(path.toString()).thenReturn("test-server");
+
+        Path migratedPath = storage.migrate(path);
+        assertNotNull(migratedPath);
+
+        verify(ioService, times(1)).delete(any(Path.class));
+        verify(ioService, times( 1 )).write(any(Path.class), anyString());
+
+        assertEquals(1, migrated.size());
+        assertEquals(migrateServerXml, migrated.get(0));
+    }
+
+    @Test
+    public void testMigrationServerNameWithSpace() {
+
+        String migrateServerXml = "<org.kie.server.controller.api.model.KieServerInstance>\n" +
+                "  <identifier>my-custom-name</identifier>\n" +
+                "  <name>my custom name</name>\n" +
+                "  <version>6.2.0.Final</version>\n" +
+                "  <managedInstances>\n" +
+                "    <org.kie.server.controller.api.model.KieServerInstanceInfo>\n" +
+                "      <location>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</location>\n" +
+                "      <status>DOWN</status>\n" +
+                "    </org.kie.server.controller.api.model.KieServerInstanceInfo>\n" +
+                "  </managedInstances>\n" +
+                "  <status>DOWN</status>\n" +
+                "  <kieServerSetup>\n" +
+                "    <containers>\n" +
+                "      <org.kie.server.api.model.KieContainerResource>\n" +
+                "        <containerId>mortgages</containerId>\n" +
+                "        <releaseId>\n" +
+                "          <groupId>mortgages</groupId>\n" +
+                "          <artifactId>mortgages</artifactId>\n" +
+                "          <version>0.0.1</version>\n" +
+                "        </releaseId>\n" +
+                "        <status>STOPPED</status>\n" +
+                "      </org.kie.server.api.model.KieContainerResource>\n" +
+                "    </containers>\n" +
+                "  </kieServerSetup>\n" +
+                "</org.kie.server.controller.api.model.KieServerInstance>";
+
+        String serverImplXml = "<org.kie.workbench.common.screens.server.management.model.impl.ServerRefImpl>\n" +
+                "  <id>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</id>\n" +
+                "  <name>my custom name</name>\n" +
+                "  <username>user</username>\n" +
+                "  <password>password</password>\n" +
+                "  <status>LOADING</status>\n" +
+                "  <connectionType>REMOTE</connectionType>\n" +
+                "  <properties>\n" +
+                "    <entry>\n" +
+                "      <string>version</string>\n" +
+                "      <string>6.2.0.Final</string>\n" +
+                "    </entry>\n" +
+                "  </properties>\n" +
+                "  <containersRef>\n" +
+                "    <entry>\n" +
+                "      <string>mortgages</string>\n" +
+                "      <org.kie.workbench.common.screens.server.management.model.impl.ContainerRefImpl>\n" +
+                "        <serverId>http://localhost:8080/kie-server-6.2.0.Final-ee7/services/rest/server</serverId>\n" +
+                "        <id>mortgages</id>\n" +
+                "        <status>STOPPED</status>\n" +
+                "        <releaseId>\n" +
+                "          <groupId>mortgages</groupId>\n" +
+                "          <artifactId>mortgages</artifactId>\n" +
+                "          <version>0.0.1</version>\n" +
+                "        </releaseId>\n" +
+                "      </org.kie.workbench.common.screens.server.management.model.impl.ContainerRefImpl>\n" +
+                "    </entry>\n" +
+                "  </containersRef>\n" +
+                "</org.kie.workbench.common.screens.server.management.model.impl.ServerRefImpl>";
+
+        when(ioService.readAllString(any(Path.class))).thenReturn(serverImplXml);
+        when(fileSystem.getPath(anyString(), anyString(), anyString())).thenReturn(Mockito.mock(Path.class));
+
+        final List<String> migrated = new ArrayList<String>();
+
+        when(ioService.write(any(Path.class), anyString())).thenAnswer(new Answer() {
+            public Object answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                migrated.add((String)args[1]);
+                return null;
+            }
+        });
+
+        VFSKieServerControllerStorage storage = new VFSKieServerControllerStorage(ioService, fileSystem);
+
+        Path path = Mockito.mock(Path.class);
+        when(path.toString()).thenReturn("test-server");
+
+        Path migratedPath = storage.migrate(path);
+        assertNotNull(migratedPath);
+
+        verify(ioService, times(1)).delete(any(Path.class));
         verify(ioService, times( 1 )).write(any(Path.class), anyString());
 
         assertEquals(1, migrated.size());


### PR DESCRIPTION
…ration from 6.1 to 6.2 - fixed identifier handling, return migrated path to load migrated kie server content

@sutaakar could you please take a look?