### PR TITLE
Filter out Java source files from compilation in KieBuilder

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/backend/builder/JavaSourceFilter.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/backend/builder/JavaSourceFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.backend.builder;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.function.Predicate;
+
+import javax.inject.Qualifier;
+
+import org.kie.internal.builder.InternalKieBuilder;
+
+/**
+ * A qualifier for predicates that filter Java source files from compilation in the {@link InternalKieBuilder}.
+ * {@link Predicate} beans with this qualifier will be combined such that if any single predicate tests false
+ * for a Java source file, that file will not be compiled by the {@link InternalKieBuilder}.
+ */
+@Documented
+@Qualifier
+@Retention( RUNTIME )
+@Target( { TYPE, METHOD, FIELD, PARAMETER } )
+public @interface JavaSourceFilter {
+
+}

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuilderTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/builder/BuilderTest.java
@@ -16,6 +16,15 @@
 
 package org.kie.workbench.common.services.backend.builder;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
@@ -23,6 +32,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.drools.core.rule.TypeMetaInfo;
 import org.guvnor.common.services.project.builder.model.BuildMessage;
@@ -33,7 +43,6 @@ import org.guvnor.common.services.project.model.Project;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.runtime.KieContainer;
@@ -53,12 +62,11 @@ import org.uberfire.backend.server.util.Paths;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 @RunWith(MockitoJUnitRunner.class)
 public class BuilderTest
         extends BuilderTestBase {
+
+    private final Predicate<String> alwaysTrue = o -> true;
 
     @Mock
     private PackageNameSearchProvider packageNameSearchProvider;
@@ -106,7 +114,8 @@ public class BuilderTest
                                              new ArrayList<BuildValidationHelper>(),
                                              dependenciesClassLoaderCache,
                                              pomModelCache,
-                                             getPackageNameWhiteListService() );
+                                             getPackageNameWhiteListService(),
+                                             alwaysTrue );
 
         assertNotNull( builder.getKieContainer() );
     }
@@ -126,7 +135,8 @@ public class BuilderTest
                                              new ArrayList<BuildValidationHelper>(),
                                              dependenciesClassLoaderCache,
                                              pomModelCache,
-                                             getPackageNameWhiteListService() );
+                                             getPackageNameWhiteListService(),
+                                             alwaysTrue );
 
         final BuildResults results = builder.build();
 
@@ -155,7 +165,8 @@ public class BuilderTest
                                              new ArrayList<BuildValidationHelper>(),
                                              dependenciesClassLoaderCache,
                                              pomModelCache,
-                                             getPackageNameWhiteListService() );
+                                             getPackageNameWhiteListService(),
+                                             alwaysTrue );
 
         final BuildResults results = builder.build();
 
@@ -184,7 +195,8 @@ public class BuilderTest
                                              new ArrayList<BuildValidationHelper>(),
                                              dependenciesClassLoaderCache,
                                              pomModelCache,
-                                             getPackageNameWhiteListService() );
+                                             getPackageNameWhiteListService(),
+                                             alwaysTrue );
 
         final BuildResults results = builder.build();
 
@@ -241,7 +253,8 @@ public class BuilderTest
                                              new ArrayList<BuildValidationHelper>(),
                                              dependenciesClassLoaderCache,
                                              pomModelCache,
-                                             getPackageNameWhiteListService() );
+                                             getPackageNameWhiteListService(),
+                                             alwaysTrue );
 
         final BuildResults results = builder.build();
 
@@ -272,7 +285,8 @@ public class BuilderTest
                                              new ArrayList<BuildValidationHelper>(),
                                              dependenciesClassLoaderCache,
                                              pomModelCache,
-                                             mock( PackageNameWhiteListService.class ) );
+                                             mock( PackageNameWhiteListService.class ),
+                                             alwaysTrue );
 
         assertNull( builder.getKieContainer() );
 
@@ -303,7 +317,8 @@ public class BuilderTest
                                              new ArrayList<BuildValidationHelper>(),
                                              dependenciesClassLoaderCache,
                                              pomModelCache,
-                                             getPackageNameWhiteListService() );
+                                             getPackageNameWhiteListService(),
+                                             alwaysTrue );
 
         assertNotNull( builder.getKieContainer() );
 


### PR DESCRIPTION
This PR is required for LiveSpark, where we require the ability to prevent client-side classes with GWT dependencies from being compiled.