### PR TITLE
Migrate QE test for Source tab read-only mode

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/SourceEditorReadOnlyTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/SourceEditorReadOnlyTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.datamodeller.client;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.screens.datamodeller.model.EditorModelContent;
+import org.kie.workbench.common.screens.datamodeller.security.DataModelerFeatures;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * BZ 1169777 - Source tab inconsistencies - editing allowed.
+ */
+public class SourceEditorReadOnlyTest extends DataModelerScreenPresenterTestBase {
+
+    private static final String ROLE_CAN_EDIT_JAVA_SOURCE = "edit 1";
+    private final Set<String> rolesThatCanEditJavaSource;
+    private final Set<Role> userRoles;
+    @Mock
+    private User user;
+    @Mock
+    private Role roleCanEditJavaSource;
+    @Mock
+    private Role roleOther1;
+    @Mock
+    private Role roleOther2;
+
+    public SourceEditorReadOnlyTest() {
+        HashSet<String> r1 = new HashSet<>();
+        r1.add(ROLE_CAN_EDIT_JAVA_SOURCE);
+        r1.add("edit 2");
+        rolesThatCanEditJavaSource = Collections.unmodifiableSet(r1);
+        userRoles = new HashSet<>();
+    }
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // usual boilerplate code
+        final boolean loadTypesInfo = true;
+        EditorModelContent content = createContent(loadTypesInfo, false);
+        when(versionRecordManager.getCurrentPath()).thenReturn(path);
+        when(modelerService.loadContent(path, loadTypesInfo)).thenReturn(content);
+        when(javaSourceEditor.getContent()).thenReturn(content.getSource());
+
+        // roles related setup
+        when(kieACL.getGrantedRoles(DataModelerFeatures.EDIT_SOURCES)).thenReturn(rolesThatCanEditJavaSource);
+        when(sessionInfo.getIdentity()).thenReturn(user);
+        when(user.getRoles()).thenReturn(userRoles);
+        when(roleCanEditJavaSource.getName()).thenReturn(ROLE_CAN_EDIT_JAVA_SOURCE);
+        when(roleOther1.getName()).thenReturn("role 1");
+        when(roleOther2.getName()).thenReturn("role 2");
+
+        // each test starts with an empty set of user roles
+        userRoles.clear();
+    }
+
+    @Test
+    public void testSourceEditorEditable() {
+        userRoles.add(roleOther1);
+        userRoles.add(roleCanEditJavaSource);
+        presenter.onStartup(path, placeRequest);
+        presenter.loadContent();
+        verify(javaSourceEditor, atLeastOnce()).setReadonly(false);
+    }
+
+    @Test
+    public void testSourceEditorReadOnly() {
+        userRoles.add(roleOther1);
+        userRoles.add(roleOther2);
+        presenter.onStartup(path, placeRequest);
+        presenter.loadContent();
+        verify(javaSourceEditor, atLeastOnce()).setReadonly(true);
+    }
+}


### PR DESCRIPTION
This test replaces QE Selenium test for [BZ 1169777 - Source tab inconsistencies - editing allowed](https://bugzilla.redhat.com/show_bug.cgi?id=1169777). The expected result of this BZ is that "analyst" role(s) are not allowed to edit Data Object's Java source directly. Compared to existing Selenium test, this unit test doesn't provide 1:1 coverage because it doesn't work with concrete roles. So any changes in [policy file](https://github.com/droolsjbpm/kie-wb-distributions/blob/7e3c0f3/kie-drools-wb/kie-drools-wb-webapp/src/main/resources/workbench-policy.properties#L63) won't be detected by this test while Selenium test would fail with an analyst user if the restriction was removed from the policy file.

I believe this test is useful because it adds some missing (not 100% sure) coverage, I'm just not sure if we can remove the original Selenium test. @jhrcek wdyt?