### PR TITLE
Add test coverage for various filename validation related bits

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewPackageHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewPackageHandler.java
@@ -41,15 +41,22 @@ import org.uberfire.workbench.type.ResourceTypeDefinition;
 public class NewPackageHandler
         extends DefaultNewResourceHandler {
 
-    @Inject
     private Caller<KieProjectService> projectService;
-
-    @Inject
     private Caller<ValidationService> validationService;
-
-    @Inject
     //We don't really need this for Packages but it's required by DefaultNewResourceHandler
     private AnyResourceTypeDefinition resourceType;
+
+    public NewPackageHandler() {
+    }
+
+    @Inject
+    public NewPackageHandler( Caller<KieProjectService> projectService,
+                              Caller<ValidationService> validationService,
+                              AnyResourceTypeDefinition resourceType ) {
+        this.projectService = projectService;
+        this.validationService = validationService;
+        this.resourceType = resourceType;
+    }
 
     @Override
     public String getDescription() {
@@ -69,7 +76,7 @@ public class NewPackageHandler
     @Override
     public void validate( final String packageName,
                           final ValidatorWithReasonCallback callback ) {
-        if ( packagesListBox.getSelectedPackage() == null ) {
+        if ( getPackage() == null ) {
             Window.alert( CommonConstants.INSTANCE.MissingPath() );
             callback.onFailure();
             return;

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewPackageHandlerTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/handlers/NewPackageHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.handlers;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.model.Package;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.validation.ValidationService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.workbench.type.AnyResourceTypeDefinition;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NewPackageHandlerTest {
+
+    @Mock
+    private ValidationService validationService;
+    @Mock
+    private ValidatorWithReasonCallback callback;
+
+    @InjectMocks
+    private NewPackageHandler handler;
+
+    private org.guvnor.common.services.project.model.Package mockpkg;
+
+    @Before
+    public void setUp() {
+        handler = new NewPackageHandler(mock(Caller.class),
+                                        new CallerMock<>(validationService),
+                                        mock(AnyResourceTypeDefinition.class)) {
+            @Override
+            public Package getPackage() {
+                return mockpkg;
+            }
+        };
+    }
+
+    @Test
+    public void validate_noPackageSelected() {
+        mockpkg = null;
+
+        handler.validate("mockpkg", callback);
+
+        verify(callback).onFailure();
+        verify(callback, never()).onFailure(anyString());
+        verify(callback, never()).onSuccess();
+    }
+
+    @Test
+    public void validate_invalidPackageName() {
+        mockpkg = mock(org.guvnor.common.services.project.model.Package.class);
+        when(validationService.isPackageNameValid(anyString())).thenReturn(false);
+
+        handler.validate("mockpkg", callback);
+
+        verify(callback, never()).onFailure();
+        verify(callback).onFailure(anyString());
+        verify(callback, never()).onSuccess();
+    }
+
+    @Test
+    public void validate_validPackageName() {
+        mockpkg = mock(org.guvnor.common.services.project.model.Package.class);
+        when(validationService.isPackageNameValid(anyString())).thenReturn(true);
+
+        handler.validate("mockpkg", callback);
+
+        verify(callback, never()).onFailure();
+        verify(callback, never()).onFailure(anyString());
+        verify(callback).onSuccess();
+    }
+}

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/validation/PackageNameValidator.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/validation/PackageNameValidator.java
@@ -59,6 +59,9 @@ public class PackageNameValidator implements FileNameValidator {
 
     @Override
     public boolean isValid( final String value ) {
+        if ( value == null ) {
+            return false;
+        }
         final Map<String, Boolean> results = evaluateIdentifiers( value.split( "\\.",
                                                                                -1 ) );
         return !results.containsValue( Boolean.FALSE );

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/PackageNameValidatorTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/PackageNameValidatorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.backend.validation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class PackageNameValidatorTest {
+
+    private static final PackageNameValidator VALIDATOR = new PackageNameValidator();
+
+    @Parameters
+    public static Object[][] data() {
+        return new Object[][]{{null, false},
+                              {"", false},
+                              {" ", false},
+                              {"\n", false},
+                              {"\\", false},
+                              {"/", false},
+                              {"\r", false},
+                              {"\t", false},
+                              {"\"", false},
+                              {"`", false},
+                              {"?", false},
+                              {"*", false},
+                              {"<", false},
+                              {">", false},
+                              {"|", false},
+                              {":", false},
+
+                              {".", false},
+                              {"..", false},
+                              {". ", false},
+                              {" .", false},
+                              {".-.", false},
+
+                              {"a z", false},
+                              {"a\nz", false},
+                              {"a\\z", false},
+                              {"a/z", false},
+                              {"a\rz", false},
+                              {"a\tz", false},
+                              {"a\"z", false},
+                              {"a`z", false},
+                              {"a?z", false},
+                              {"a*z", false},
+                              {"a<z", false},
+                              {"a>z", false},
+                              {"a|z", false},
+                              {"a:z", false},
+                              {"a-z", false},
+
+                              {"123", false},
+                              {"int", false},
+
+                              {"a", true},
+                              {"a.z", true},
+                              {"under_score", true},
+                              {"_int.x123", true}};
+    }
+
+    @Parameter(0)
+    public String input;
+    @Parameter(1)
+    public boolean valid;
+
+    @Test
+    public void isValid() {
+        assertEquals(valid, VALIDATOR.isValid(input));
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/ValidationServiceImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/ValidationServiceImplTest.java
@@ -16,24 +16,31 @@
 
 package org.kie.workbench.common.services.backend.validation;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.service.ValidationService;
+
+@RunWith(MockitoJUnitRunner.class)
 public class ValidationServiceImplTest {
 
+    @Mock
+    private ValidationService uberfireValidationService;
+    @Mock
+    private PackageNameValidator packageValidator;
+    @Mock
+    private ProjectNameValidator projectValidator;
+    @Mock
+    private JavaFileNameValidator javaValidator;
+
+    @InjectMocks
     private ValidationServiceImpl validationService;
-
-    @Before
-    public void setUp() throws Exception {
-        validationService = new ValidationServiceImpl( mock( org.uberfire.ext.editor.commons.service.ValidationService.class ),
-                                                       mock( PackageNameValidator.class ),
-                                                       mock( ProjectNameValidator.class ),
-                                                       mock( JavaFileNameValidator.class ) );
-
-    }
 
     @Test
     public void testValidateGroup() {
@@ -60,13 +67,31 @@ public class ValidationServiceImplTest {
     }
 
     @Test
-    public void testValidateVersion() throws Exception {
-        assertTrue( validationService.validateGAVVersion( "1111" ) );
-        assertTrue( validationService.validateGAVVersion( "1.0-SNAPSHOT" ) );
-        assertTrue( validationService.validateGAVVersion( "1.1.Final" ) );
-        assertTrue( validationService.validateGAVVersion( "1.1-Final" ) );
-        assertTrue( validationService.validateGAVVersion( "1.1-Beta-11" ) );
+    public void testValidateVersion() {
+        assertTrue(validationService.validateGAVVersion("1111"));
+        assertTrue(validationService.validateGAVVersion("1.0-SNAPSHOT"));
+        assertTrue(validationService.validateGAVVersion("1.1.Final"));
+        assertTrue(validationService.validateGAVVersion("1.1-Final"));
+        assertTrue(validationService.validateGAVVersion("1.1-Beta-11"));
 
-        assertFalse( validationService.validateGAVVersion( "1.1 Beta 11" ) );
+        assertFalse(validationService.validateGAVVersion("1.1 Beta 11"));
+    }
+
+    @Test
+    public void testValidatorsCalled() {
+        String mockName = "bxmsftw";
+        Path mockPath = mock(Path.class);
+
+        validationService.isProjectNameValid(mockName);
+        validationService.isPackageNameValid(mockName);
+        validationService.isFileNameValid(mockPath, mockName);
+        validationService.isJavaFileNameValid(mockName);
+        validationService.isFileNameValid(mockName);
+
+        verify(projectValidator).isValid(mockName);
+        verify(packageValidator).isValid(mockName);
+        verify(uberfireValidationService).isFileNameValid(mockPath, mockName);
+        verify(javaValidator).isValid(mockName);
+        verify(uberfireValidationService).isFileNameValid(mockName);
     }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourceView.java
@@ -121,7 +121,7 @@ public class NewResourceView extends BaseModal implements NewResourcePresenter.V
         }
     }
 
-    private void onOKButtonClick() {
+    void onOKButtonClick() {
         //Generic validation
         final String fileName = fileNameTextBox.getText();
         if ( fileName == null || fileName.trim().isEmpty() ) {

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourceViewTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourceViewTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.handlers;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.gwtbootstrap3.client.ui.ModalHeader;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
+
+@WithClassesToStub(ModalHeader.class)
+@RunWith(GwtMockitoTestRunner.class)
+public class NewResourceViewTest {
+
+    @Mock
+    private NewResourcePresenter presenter;
+
+    @InjectMocks
+    private NewResourceView view;
+
+    private ArgumentCaptor<ValidatorWithReasonCallback> callbackCaptor = ArgumentCaptor.forClass(ValidatorWithReasonCallback.class);
+
+    @Before
+    public void setUp() {
+        view.init(presenter);
+    }
+
+    /* Test that regular input is validated, ... */
+
+    @Test
+    public void validateOnOKButtonClick_regularFileName() {
+        when(view.fileNameTextBox.getText()).thenReturn("mock");
+        view.onOKButtonClick();
+        verify(presenter).validate(anyString(), any(ValidatorWithReasonCallback.class));
+    }
+
+    /* ... that any kind of 'empty' input gets caught even before validation and results in error state and message. */
+
+    @Test
+    public void validateOnOKButtonClick_nullFileName() {
+        when(view.fileNameTextBox.getText()).thenReturn(null);
+        testOnOKButtonClick_emptyFileNames();
+    }
+
+    @Test
+    public void validateOnOKButtonClick_emptyFileName() {
+        when(view.fileNameTextBox.getText()).thenReturn("");
+        testOnOKButtonClick_emptyFileNames();
+    }
+
+    @Test
+    public void validateOnOKButtonClick_whitespaceFileName() {
+        when(view.fileNameTextBox.getText()).thenReturn("\t");
+        testOnOKButtonClick_emptyFileNames();
+    }
+
+    private void testOnOKButtonClick_emptyFileNames() {
+        view.onOKButtonClick();
+        verify(view.fileNameGroup).setValidationState(ValidationState.ERROR);
+        verify(view.fileNameHelpInline).setText(anyString());
+        verify(presenter, never()).validate(anyString(), any(ValidatorWithReasonCallback.class));
+    }
+
+    /* If validation fails, no item is created, the callback should also set the error state ... */
+
+    @Test
+    public void callbackOnValidationFailure_noReason() {
+        getCallback().onFailure();
+        verify(view.fileNameGroup).setValidationState(ValidationState.ERROR);
+        verify(presenter, never()).makeItem(anyString());
+    }
+
+    /* and show any reason given. */
+
+    @Test
+    public void callbackOnValidationFailure_withReason() {
+        getCallback().onFailure("mock reason");
+        verify(view.fileNameGroup).setValidationState(ValidationState.ERROR);
+        verify(view.fileNameHelpInline).setText("mock reason");
+        verify(presenter, never()).makeItem(anyString());
+    }
+
+    /* Whereas successful validation results in item being created. */
+
+    @Test
+    public void callbackOnValidationsuccess() {
+        getCallback().onSuccess();
+        verify(view.fileNameGroup).setValidationState(ValidationState.NONE);
+        verify(presenter).makeItem(anyString());
+    }
+
+    private ValidatorWithReasonCallback getCallback() {
+        when(view.fileNameTextBox.getText()).thenReturn("mock");
+        view.onOKButtonClick();
+        verify(presenter).validate(anyString(), callbackCaptor.capture());
+
+        return callbackCaptor.getValue();
+    }
+}


### PR DESCRIPTION
This time hopefully with correct license headers and without typos. :)

There are some small code changes - added `null` check, method made package private to enable testing, moving `NewPackageHandler` from field injection to constructor injection (as is already done for `NewProjectHandler`) and reusing `DefaultNewResourceHandler.getPackage()`.

Related BZs:
- 1006506 - File name validation broken
- 1062289 - Create new Package dialog displays no warning when using " in package name

(part n+1 in 'Moving tests to community', soon in your theaters)