### PR TITLE
GUVNOR-2507: Guided Decision Table Editor: Add ability to open multiple decision tables in the same view

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
+++ b/kie-wb-common-widgets/kie-wb-common-ui/pom.xml
@@ -159,6 +159,11 @@
       <artifactId>uberfire-widgets-service-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/alert/AlertPopupView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/alert/AlertPopupView.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.alert;
+
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.IsWidget;
+
+/**
+ * A simple popup that alerts Users to a message. Equivalent to {@link Window#alert(String)}.
+ */
+public interface AlertPopupView extends IsWidget {
+
+    /**
+     * Shows the popup with associated title and message.
+     * @param title The title of the popup
+     * @param message The message to show
+     */
+    void alert(final String title,
+               final String message);
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/alert/AlertPopupViewImpl.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/alert/AlertPopupViewImpl.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="well">
+  <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+  <span id="alert-message"></span>
+</div>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/alert/AlertPopupViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/alert/AlertPopupViewImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.alert;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.ui.Composite;
+import org.jboss.errai.common.client.dom.Span;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKButton;
+
+@Dependent
+@Templated
+public class AlertPopupViewImpl extends Composite
+        implements AlertPopupView {
+
+    @Inject
+    @DataField("alert-message")
+    Span alertMessage;
+
+    private final BaseModal modal;
+
+    public AlertPopupViewImpl() {
+        super();
+        this.modal = new BaseModal();
+    }
+
+    @PostConstruct
+    void setup() {
+        this.modal.setBody( this );
+        this.modal.add( new ModalFooterOKButton( modal::hide ) );
+    }
+
+    @Override
+    public void alert( final String title,
+                       final String message ) {
+        this.modal.setTitle( title );
+        this.alertMessage.setInnerHTML( getSafeHtml( message ).asString() );
+        modal.show();
+    }
+
+    private SafeHtml getSafeHtml( final String message ) {
+        final SafeHtmlBuilder shb = new SafeHtmlBuilder();
+        shb.appendEscaped( message );
+        return shb.toSafeHtml();
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieDocument.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieDocument.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client;
+
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.client.mvp.LockManager;
+import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.mvp.PlaceRequest;
+
+/**
+ * Definition of a document that can hosted in KIE's Multiple Document Editor
+ */
+public interface KieDocument {
+
+    /**
+     * Returns the current version of the document. Can be null if it is the "latest" version.
+     * The version is identical to that used by {@link VersionRecordManager}.
+     * @return
+     */
+    String getVersion();
+
+    /**
+     * Sets the current version of the document. This is called automatically by
+     * {@link KieMultipleDocumentEditor} in response to changes to the document
+     * version from the {@link VersionRecordManager} .
+     * @param version
+     */
+    void setVersion( final String version );
+
+    /**
+     * Returns the "latest" path for the document. Latest is the tip/head version.
+     * @return Can be null.
+     */
+    ObservablePath getLatestPath();
+
+    /**
+     * Sets the "latest" path for the document. This is called automatically by
+     * {@link KieMultipleDocumentEditor} when an older version of a document is
+     * restored and hence the latest version changes.
+     * @param latestPath Can be null.
+     */
+    void setLatestPath( final ObservablePath latestPath );
+
+    /**
+     * Returns the "current" path for the document reflecting
+     * the version selected in {@link VersionRecordManager}
+     * @return Cannot be null.
+     */
+    ObservablePath getCurrentPath();
+
+    /**
+     * Sets the "current" path for the document. This is called automatically by
+     * {@link VersionRecordManager} in response to a different version of the document
+     * being selected; and in response to restoration of an older version of the document.
+     * @param currentPath Cannot be null.
+     */
+    void setCurrentPath( final ObservablePath currentPath );
+
+    /**
+     * Returns the original {@link PlaceRequest} associated with the {@link KieMultipleDocumentEditor}
+     * when first initialised. The {@link PlaceRequest} is used to support changes to the Editor title.
+     * Subclasses may also need to use this to support different {@link LockManager} configurations.
+     * @return
+     */
+    PlaceRequest getPlaceRequest();
+
+    /**
+     * Returns whether the document is read-only; normally when {@link KieDocument#getCurrentPath()}
+     * points to version that is not the "latest" version however can also be set by subclasses for
+     * example should attempts to lock the document for editing fail.
+     * @return
+     */
+    boolean isReadOnly();
+
+    /**
+     * Sets whether the document is read-only. This is called automatically by {@link KieMultipleDocumentEditor}
+     * in response to Users selecting a version of the document that is not the lastest.
+     * @param isReadOnly
+     */
+    void setReadOnly( final boolean isReadOnly );
+
+    /**
+     * Returns the original hashCode of the model represented by the document. This is used by the hashCode-based
+     * "is dirty" mechanism; where by a document is considered dirty should the hashCode when the document was
+     * loaded differ to the document's current hashCode. This method should be used in conjunction with
+     * {@link KieMultipleDocumentEditor#mayClose(Integer, Integer)}
+     * @return
+     */
+    Integer getOriginalHashCode();
+
+    /**
+     * Sets the "original" hashCode. This is called automatically by {@link KieMultipleDocumentEditor#getSaveSuccessCallback(KieDocument, int)}
+     * when a document has been successfully saved; effectively resetting the "is dirty" mechansism. Subclasses may also call this to set
+     * the documents original hashCode after the document has been loaded. However by default this will be null and operate identically
+     * to if it had been set by subclasses.
+     * @param originalHashCode
+     */
+    void setOriginalHashCode( final Integer originalHashCode );
+
+    /**
+     * Returns the concurrent modification meta-data associated with the document. This is called automatically by the
+     * concurrent modification handlers configured by {@link KieMultipleDocumentEditor#registerDocument(KieDocument)}.
+     * to check for and handle concurrent modifications. It should not need to be called by subclasses.
+     * @return
+     */
+    ObservablePath.OnConcurrentUpdateEvent getConcurrentUpdateSessionInfo();
+
+    /**
+     * Sets the concurrent modification meta-data. This is called automatically by the concurrent modification handlers
+     * configured by {@link KieMultipleDocumentEditor#registerDocument(KieDocument)}. It should not need to be called
+     * by subclasses directly.
+     * @param concurrentUpdateSessionInfo
+     */
+    void setConcurrentUpdateSessionInfo( final ObservablePath.OnConcurrentUpdateEvent concurrentUpdateSessionInfo );
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorPresenter.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorPresenter.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client;
+
+import java.util.List;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.drools.workbench.models.datamodel.imports.Imports;
+import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.metadata.client.KieEditorWrapperView.KieEditorWrapperPresenter;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.callbacks.Callback;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.menu.Menus;
+
+public interface KieMultipleDocumentEditorPresenter<D extends KieDocument> extends KieEditorWrapperPresenter {
+
+    /**
+     * The Widget for this Editor. To be returned by subclasses @WorkbenchPartView method.
+     * @return
+     */
+    IsWidget getWidget();
+
+    /**
+     * The title decoration for this Editor. To be returned by subclasses @WorkbenchPartTitleDecoration method.
+     * @param document The document for which to get the title widget. Cannot be null.
+     * @return
+     */
+    IsWidget getTitleWidget( final D document );
+
+    /**
+     * The Menus for this Editor. To be returned by subclasses @WorkbenchMenu method.
+     * @return
+     */
+    Menus getMenus();
+
+    /**
+     * Construct the default Menus, consisting of "Save", "Copy", "Rename", "Delete",
+     * "Validate" and "VersionRecordManager" drop-down. Subclasses can override this
+     * to customize their Menus.
+     */
+    void makeMenuBar();
+
+    /**
+     * Ensure resources are released correctly. To be used by subclasses @OnClose method.
+     */
+    void onClose();
+
+    /**
+     * Register a new document in the MDI container. The document's Path is configured with concurrent lock handlers.
+     * @param document The document to register. Cannot be null.
+     */
+    void registerDocument( final D document );
+
+    /**
+     * Deregister an existing document from the MDI container.
+     * @param document The document to deregister. Cannot be null.
+     */
+    void deregisterDocument( final D document );
+
+    /**
+     * Activate a document. Activation initialises the VersionRecordManager drop-down and Editor tabs
+     * with the content of the document. Subclasses could call this, for example, when a document
+     * has been selected.
+     * @param document The document to activate. Cannot be null.
+     * @param overview The {@link Overview} associated with the document. Cannot be null.
+     * @param dmo The {@link AsyncPackageDataModelOracle} associated with the document. Cannot be null.
+     * @param imports The {@link Imports} associated with the document. Cannot be null.
+     * @param isReadOnly true if the document is read-only.
+     */
+    void activateDocument( final D document,
+                           final Overview overview,
+                           final AsyncPackageDataModelOracle dmo,
+                           final Imports imports,
+                           final boolean isReadOnly );
+
+    /**
+     * Get the active document. Can return null.
+     * @return
+     */
+    D getActiveDocument();
+
+    /**
+     * Load a document. Once a document has been loaded it should be registered to the MDI container.
+     * @param path Provided by Uberfire to the @WorkbenchEditor's @OnStartup method.
+     * @param placeRequest Provided by Uberfire to the @WorkbenchEditor's @OnStartup method.
+     */
+    void loadDocument( final ObservablePath path,
+                       final PlaceRequest placeRequest );
+
+    /**
+     * Refresh a document due to a change in the selected version.
+     * @param document
+     */
+    void refreshDocument( final D document );
+
+    /**
+     * Remove a document from the MDI container.
+     * @param document
+     */
+    void removeDocument( final D document );
+
+    /**
+     * Get a title for the document to show in the WorkbenchPart's title widget.
+     * @param document
+     * @return
+     */
+    String getDocumentTitle( final D document );
+
+    /**
+     * The "View Source" tab has been selected. Subclasses should generate the source for the document
+     * and update the "View Source" widget's content with {@link #updateSource(String)} .
+     * @param document
+     * @return
+     */
+    void onSourceTabSelected( final D document );
+
+    /**
+     * Update the "View Source" widget's content.
+     * @param source
+     */
+    void updateSource( final String source );
+
+    /**
+     * The "Validate" MenuItem has been selected. Subclasses should perform validation of the document.
+     * @param document
+     * @return
+     */
+    void onValidate( final D document );
+
+    /**
+     * The "Save" MenuItem has been selected. Subclasses should save the document. The
+     * {@link KieMultipleDocumentEditor#getSaveSuccessCallback(KieDocument, int)} should
+     * be used to ensure the "isDirty" mechanism is correctly updated.
+     * @param document
+     * @param commitMessage
+     * @return
+     */
+    void onSave( final D document,
+                 final String commitMessage );
+
+    /**
+     * Check whether a document can be closed. The original hashCode can be retrieved from the document.
+     * The current hashCode should be retrieved from the document's model. To be used in conjunction with
+     * subclasses @OnMayClose method.
+     * @param originalHashCode The document's model original hashCode.
+     * @param currentHashCode The document's model current hashCode.
+     * @return
+     */
+    boolean mayClose( final Integer originalHashCode,
+                      final Integer currentHashCode );
+
+    /**
+     * Called in response to the User selecting an additional document to open in the editor.
+     * @param path The Path to the document to open.
+     */
+    void onOpenDocumentInEditor( final Path path );
+
+    /**
+     * Returns a list of Paths to *all* documents that can be opened in the editor,
+     * including those that may be potentially already open in the editor.
+     * @param callback The callback returns the list of additional documents; thus supporting asynchronous retrieval of documents.
+     */
+    void getAvailableDocumentPaths( final Callback<List<Path>> callback );
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorQualifier.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorQualifier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+/**
+ * A qualifier for removing ambiguity between the beans created for {@link KieMultipleDocumentEditor} and other {@link KieEditor}.
+ */
+@Documented
+@Qualifier
+@Retention(RUNTIME)
+@Target({ TYPE, FIELD, PARAMETER, METHOD })
+public @interface KieMultipleDocumentEditorQualifier {
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorWrapperView.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorWrapperView.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client;
+
+import java.util.List;
+
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.mvp.UberView;
+
+public interface KieMultipleDocumentEditorWrapperView extends KieEditorWrapperView,
+                                                              UberView<KieMultipleDocumentEditorPresenter> {
+
+    /**
+     * Shows an informative message to Users that there are no additional documents available that can be opened in the editor .
+     */
+    void showNoAdditionalDocuments();
+
+    /**
+     * Shows a list of paths to documents that can be opened in the editor from which the User can select on to open.
+     * The selected document can be opened in the editor by calling {@link KieMultipleDocumentEditorPresenter#onOpenDocumentInEditor(Path)}
+     * @param paths Paths to documents that can be opened in the editor.
+     */
+    void showAdditionalDocuments( final List<Path> paths );
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorWrapperViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorWrapperViewImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client;
+
+import java.util.List;
+import javax.inject.Inject;
+
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.widgets.client.popups.alert.AlertPopupView;
+import org.kie.workbench.common.widgets.metadata.client.popups.SelectDocumentPopupPresenter;
+import org.kie.workbench.common.widgets.metadata.client.resources.i18n.KieMultipleDocumentEditorConstants;
+import org.uberfire.backend.vfs.Path;
+
+@KieMultipleDocumentEditorQualifier
+public class KieMultipleDocumentEditorWrapperViewImpl
+        extends KieEditorWrapperViewImpl
+        implements KieMultipleDocumentEditorWrapperView {
+
+    protected KieMultipleDocumentEditorPresenter presenter;
+
+    protected AlertPopupView noDocumentsPopup;
+    protected SelectDocumentPopupPresenter selectDocumentPopup;
+    protected TranslationService translationService;
+
+    @Inject
+    void setTranslationService( final TranslationService translationService ) {
+        this.translationService = translationService;
+    }
+
+    @Inject
+    void setNoDocumentsPopup( final AlertPopupView noDocumentsPopup ) {
+        this.noDocumentsPopup = noDocumentsPopup;
+    }
+
+    @Inject
+    void setSelectDocumentPopup( final SelectDocumentPopupPresenter selectDocumentPopup ) {
+        this.selectDocumentPopup = selectDocumentPopup;
+    }
+
+    @Override
+    public void init( final KieMultipleDocumentEditorPresenter presenter ) {
+        this.presenter = presenter;
+        this.selectDocumentPopup.setEditorPresenter( presenter );
+    }
+
+    @Override
+    public void showNoAdditionalDocuments() {
+        noDocumentsPopup.alert( translationService.getTranslation( KieMultipleDocumentEditorConstants.NoDocuments_Title ),
+                                translationService.getTranslation( KieMultipleDocumentEditorConstants.NoDocuments_Message ) );
+    }
+
+    @Override
+    public void showAdditionalDocuments( final List<Path> paths ) {
+        selectDocumentPopup.setDocuments( paths );
+        selectDocumentPopup.show();
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/DocumentMenuItemImpl.html
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/DocumentMenuItemImpl.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div id="kie-document-registration">
+
+  <style scoped>
+    .kie-document-active {
+      background-color: cornflowerblue;
+    }
+
+    .kie-document-inactive {
+      background-color: lightblue;
+    }
+
+    .kie-document-base {
+      cursor: pointer;
+      padding: 2px 2px 2px 2px;
+      margin-bottom: 2px;
+      width: 100%;
+    }
+
+    .kie-document-close {
+      float: right;
+      padding-right: 2px;
+      cursor: pointer;
+    }
+
+  </style>
+
+  <div id="kie-document-close" class="fa fa-times kie-document-close"></div>
+  <div id="kie-document-name" class="kie-document-base"></div>
+
+</div>

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/DocumentMenuItemImpl.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/DocumentMenuItemImpl.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.menu;
+
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.mvp.Command;
+
+@Templated
+public class DocumentMenuItemImpl implements RegisteredDocumentsMenuView.DocumentMenuItem {
+
+    private static final String ACTIVE_CSS_CLASS = "kie-document-active";
+    private static final String INACTIVE_CSS_CLASS = "kie-document-inactive";
+
+    private String name;
+    private Command activateDocumentCommand;
+    private Command removeDocumentCommand;
+
+    @Inject
+    @DataField("kie-document-name")
+    Div kieDocumentName;
+
+    @Inject
+    @DataField("kie-document-registration")
+    Div kieDocumentRegistration;
+
+    @Inject
+    @DataField("kie-document-close")
+    Div kieDocumentClose;
+
+    @Override
+    public HTMLElement getElement() {
+        return kieDocumentRegistration;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void setName( final String name ) {
+        this.name = name;
+        this.kieDocumentName.setInnerHTML( getSafeHtml( name ).asString());
+    }
+
+    private SafeHtml getSafeHtml( final String message ) {
+        final SafeHtmlBuilder shb = new SafeHtmlBuilder();
+        shb.appendEscaped( message );
+        return shb.toSafeHtml();
+    }
+
+    @Override
+    public void setActivateDocumentCommand( final Command activateDocumentCommand ) {
+        this.activateDocumentCommand = PortablePreconditions.checkNotNull( "activateDocumentCommand",
+                                                                           activateDocumentCommand );
+    }
+
+    @Override
+    public void setRemoveDocumentCommand( final Command removeDocumentCommand ) {
+        this.removeDocumentCommand = PortablePreconditions.checkNotNull( "removeDocumentCommand",
+                                                                         removeDocumentCommand );
+    }
+
+    @Override
+    public void setActive( final boolean isActive ) {
+        if ( isActive ) {
+            kieDocumentRegistration.setClassName( ACTIVE_CSS_CLASS );
+        } else {
+            kieDocumentRegistration.setClassName( INACTIVE_CSS_CLASS );
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler("kie-document-name")
+    public void onClickFileName( final ClickEvent e ) {
+        if ( this.activateDocumentCommand != null ) {
+            activateDocumentCommand.execute();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler("kie-document-close")
+    public void onClickClose( final ClickEvent e ) {
+        if ( this.removeDocumentCommand != null ) {
+            removeDocumentCommand.execute();
+        }
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuBuilder.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuBuilder.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.menu;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.kie.workbench.common.widgets.metadata.client.KieDocument;
+import org.kie.workbench.common.widgets.metadata.client.menu.RegisteredDocumentsMenuView.DocumentMenuItem;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+import org.uberfire.workbench.model.menu.MenuFactory;
+import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
+
+@Dependent
+public class RegisteredDocumentsMenuBuilder implements MenuFactory.CustomMenuBuilder,
+                                                       RegisteredDocumentsMenuView.Presenter {
+
+    private Command saveDocumentsCommand;
+    private Command openDocumentCommand;
+    private ParameterizedCommand<KieDocument> activateDocumentCommand;
+    private ParameterizedCommand<KieDocument> removeDocumentCommand;
+
+    private RegisteredDocumentsMenuView view;
+    private SyncBeanManager beanManager;
+
+    private Map<KieDocument, DocumentMenuItem> registeredDocuments = new HashMap<>();
+
+    @Inject
+    public RegisteredDocumentsMenuBuilder( final RegisteredDocumentsMenuView view,
+                                           final SyncBeanManager beanManager ) {
+        this.view = view;
+        this.beanManager = beanManager;
+    }
+
+    @PostConstruct
+    void setup() {
+        view.init( this );
+    }
+
+    @Override
+    public void push( final MenuFactory.CustomMenuBuilder element ) {
+    }
+
+    @Override
+    public MenuItem build() {
+        return new BaseMenuCustom<IsWidget>() {
+            @Override
+            public IsWidget build() {
+                return ElementWrapperWidget.getWidget( view.getElement() );
+            }
+
+            @Override
+            public boolean isEnabled() {
+                return view.isEnabled();
+            }
+
+            @Override
+            public void setEnabled( final boolean enabled ) {
+                view.setEnabled( enabled );
+            }
+
+            @Override
+            public String getSignatureId() {
+                return "org.kie.workbench.common.widgets.metadata.client.menu.RegisteredDocumentsMenuBuilder";
+            }
+
+        };
+    }
+
+    @Override
+    public void onOpenDocument() {
+        if ( openDocumentCommand != null ) {
+            openDocumentCommand.execute();
+        }
+    }
+
+    @Override
+    public void onSaveDocuments() {
+        if ( saveDocumentsCommand != null ) {
+            saveDocumentsCommand.execute();
+        }
+    }
+
+    @Override
+    public void registerDocument( final KieDocument document ) {
+        final DocumentMenuItem documentMenuItem = makeDocumentMenuItem( document );
+        registeredDocuments.put( document,
+                                 documentMenuItem );
+        view.addDocument( documentMenuItem );
+    }
+
+    @Override
+    public void deregisterDocument( final KieDocument document ) {
+        final DocumentMenuItem documentMenuItem = registeredDocuments.remove( document );
+        beanManager.destroyBean( documentMenuItem );
+        view.deleteDocument( documentMenuItem );
+    }
+
+    @Override
+    public void onActivateDocument( final KieDocument document ) {
+        if ( activateDocumentCommand != null ) {
+            activateDocumentCommand.execute( document );
+        }
+    }
+
+    @Override
+    public void onRemoveDocument( final KieDocument document ) {
+        if ( removeDocumentCommand != null ) {
+            removeDocumentCommand.execute( document );
+        }
+    }
+
+    @Override
+    public void setOpenDocumentCommand( final Command openDocumentCommand ) {
+        this.openDocumentCommand = PortablePreconditions.checkNotNull( "openDocumentCommand",
+                                                                       openDocumentCommand );
+    }
+
+    @Override
+    public void setSaveDocumentsCommand( final Command saveDocumentsCommand ) {
+        this.saveDocumentsCommand = PortablePreconditions.checkNotNull( "saveDocumentsCommand",
+                                                                        saveDocumentsCommand );
+    }
+
+    @Override
+    public void setActivateDocumentCommand( final ParameterizedCommand<KieDocument> activateDocumentCommand ) {
+        this.activateDocumentCommand = PortablePreconditions.checkNotNull( "activateDocumentCommand",
+                                                                           activateDocumentCommand );
+    }
+
+    @Override
+    public void setRemoveDocumentCommand( final ParameterizedCommand<KieDocument> removeDocumentCommand ) {
+        this.removeDocumentCommand = PortablePreconditions.checkNotNull( "removeDocumentCommand",
+                                                                         removeDocumentCommand );
+    }
+
+    @Override
+    public void activateDocument( final KieDocument document ) {
+        for ( Map.Entry<KieDocument, DocumentMenuItem> e : registeredDocuments.entrySet() ) {
+            e.getValue().setActive( e.getKey().equals( document ) );
+        }
+    }
+
+    @Override
+    public void dispose() {
+        view.clear();
+        for ( DocumentMenuItem documentMenuItem : registeredDocuments.values() ) {
+            beanManager.destroyBean( documentMenuItem );
+        }
+        registeredDocuments.clear();
+    }
+
+    DocumentMenuItem makeDocumentMenuItem( final KieDocument document ) {
+        final DocumentMenuItem documentMenuItem = beanManager.lookupBean( DocumentMenuItem.class ).newInstance();
+        documentMenuItem.setName( document.getCurrentPath().getFileName() );
+        documentMenuItem.setRemoveDocumentCommand( () -> onRemoveDocument( document ) );
+        documentMenuItem.setActivateDocumentCommand( () -> onActivateDocument( document ) );
+        return documentMenuItem;
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuView.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuView.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.menu;
+
+import com.google.gwt.user.client.ui.HasEnabled;
+import org.jboss.errai.common.client.api.IsElement;
+import org.kie.workbench.common.widgets.metadata.client.KieDocument;
+import org.uberfire.client.mvp.UberElement;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+
+public interface RegisteredDocumentsMenuView extends UberElement<RegisteredDocumentsMenuBuilder>,
+                                                     HasEnabled {
+
+    interface Presenter {
+
+        void onOpenDocument();
+
+        void onSaveDocuments();
+
+        void registerDocument( final KieDocument document );
+
+        void deregisterDocument( final KieDocument document );
+
+        void onActivateDocument( final KieDocument document );
+
+        void onRemoveDocument( final KieDocument document );
+
+        void setOpenDocumentCommand( final Command openDocumentCommand );
+
+        void setSaveDocumentsCommand( final Command saveDocumentsCommand );
+
+        void setActivateDocumentCommand( final ParameterizedCommand<KieDocument> activateDocumentCommand );
+
+        void setRemoveDocumentCommand( final ParameterizedCommand<KieDocument> removeDocumentCommand );
+
+        void activateDocument( final KieDocument document );
+
+        void dispose();
+
+    }
+
+    interface DocumentMenuItem extends IsElement {
+
+        String getName();
+
+        void setName( final String name );
+
+        void setActivateDocumentCommand( final Command activateDocumentCommand );
+
+        void setRemoveDocumentCommand( final Command removeDocumentCommand );
+
+        void setActive( final boolean isActive );
+
+    }
+
+    void clear();
+
+    void addDocument( final DocumentMenuItem document );
+
+    void deleteDocument( final DocumentMenuItem document );
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuViewImpl.html
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuViewImpl.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div id="view" class="btn-group">
+
+  <style scoped>
+    .kie-documents-container {
+      padding: 5px 5px 5px 5px;
+      width: 300px;
+      height: 200px;
+    }
+
+    .kie-documents {
+      height: 150px;
+      overflow: auto;
+      border: solid 1px #ddd;
+      padding: 2px 2px 2px 2px;
+      margin-bottom: 10px;
+    }
+  </style>
+
+  <button id="registeredDocumentsMenuDropdown" class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown">
+    <span data-i18n-key="documents">Documents</span>
+    <span class="caret"></span>
+  </button>
+  <div class="kie-documents-container dropdown-menu dropdown-menu-right" aria-labelledby="documents">
+    <div id="registeredDocuments" class="kie-documents">
+    </div>
+    <button id="openDocumentMenuButton" class="btn btn-default btn-sm" type="button">
+      <span data-i18n-key="openDocument">Open...</span>
+    </button>
+    <button id="saveDocumentsMenuButton" class="btn btn-default btn-sm" type="button">
+      <span data-i18n-key="saveDocuments">Save all</span>
+    </button>
+  </div>
+</div>

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuViewImpl.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.menu;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import org.jboss.errai.common.client.dom.Button;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.NodeList;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+@Dependent
+@Templated
+public class RegisteredDocumentsMenuViewImpl implements RegisteredDocumentsMenuView {
+
+    @Inject
+    @DataField("view")
+    Div view;
+
+    @Inject
+    @DataField("registeredDocumentsMenuDropdown")
+    Button registeredDocumentsMenuDropdown;
+
+    @Inject
+    @DataField("registeredDocuments")
+    Div registeredDocuments;
+
+    @Inject
+    @DataField("openDocumentMenuButton")
+    Button openDocumentMenuButton;
+
+    @Inject
+    @DataField("saveDocumentsMenuButton")
+    Button saveDocumentsMenuButton;
+
+    protected RegisteredDocumentsMenuBuilder presenter;
+
+    @Override
+    public void init( final RegisteredDocumentsMenuBuilder presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return view;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return !registeredDocumentsMenuDropdown.getDisabled();
+    }
+
+    @Override
+    public void setEnabled( final boolean enabled ) {
+        registeredDocumentsMenuDropdown.setDisabled( !enabled );
+    }
+
+    @Override
+    public void clear() {
+        final NodeList children = registeredDocuments.getChildNodes();
+        for ( int i = 0; i < children.getLength(); i++ ) {
+            registeredDocuments.removeChild( children.item( i ) );
+        }
+    }
+
+    @Override
+    public void addDocument( final DocumentMenuItem document ) {
+        registeredDocuments.appendChild( document.getElement() );
+    }
+
+    @Override
+    public void deleteDocument( final DocumentMenuItem document ) {
+        registeredDocuments.removeChild( document.getElement() );
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler("openDocumentMenuButton")
+    public void onClickOpenDocumentButton( final ClickEvent e ) {
+        presenter.onOpenDocument();
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler("saveDocumentsMenuButton")
+    public void onClickSaveDocumentsButton( final ClickEvent e ) {
+        presenter.onSaveDocuments();
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/SaveAllMenuBuilder.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/menu/SaveAllMenuBuilder.java
@@ -17,7 +17,7 @@
 package org.kie.workbench.common.widgets.metadata.client.menu;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
@@ -26,7 +26,7 @@ import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
-@ApplicationScoped
+@Dependent
 public class SaveAllMenuBuilder implements MenuFactory.CustomMenuBuilder,
                                            SaveAllMenuView.Presenter {
 

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopup.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopup.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.popups;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.kie.workbench.common.widgets.metadata.client.KieMultipleDocumentEditorPresenter;
+import org.kie.workbench.common.widgets.metadata.client.popups.SelectDocumentPopupView.SelectableDocumentView;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+@Dependent
+public class SelectDocumentPopup implements SelectDocumentPopupPresenter {
+
+    private SelectDocumentPopupView view;
+    private SyncBeanManager beanManager;
+
+    private KieMultipleDocumentEditorPresenter presenter;
+
+    private SelectableDocumentView selectedDocument = null;
+    private final List<SelectableDocumentView> selectableDocuments = new ArrayList<>();
+
+    @Inject
+    public SelectDocumentPopup( final SelectDocumentPopupView view,
+                                final SyncBeanManager beanManager ) {
+        this.view = view;
+        this.beanManager = beanManager;
+    }
+
+    @PostConstruct
+    void init() {
+        view.init( this );
+    }
+
+    @Override
+    public void setEditorPresenter( final KieMultipleDocumentEditorPresenter presenter ) {
+        this.presenter = PortablePreconditions.checkNotNull( "presenter",
+                                                             presenter );
+    }
+
+    @Override
+    public void setDocuments( final List<Path> paths ) {
+        PortablePreconditions.checkNotNull( "paths",
+                                            paths );
+        dispose();
+        for ( Path path : paths ) {
+            final SelectableDocumentView document = makeSelectableDocument( path );
+            selectableDocuments.add( document );
+            view.addDocument( document );
+        }
+        view.enableOKButton( false );
+    }
+
+    @Override
+    public void show() {
+        view.show();
+    }
+
+    @Override
+    public void onOK() {
+        if ( selectedDocument != null ) {
+            final Path path = selectedDocument.getPath();
+            presenter.onOpenDocumentInEditor( path );
+        }
+        view.hide();
+        dispose();
+    }
+
+    @Override
+    public void onCancel() {
+        view.hide();
+        dispose();
+    }
+
+    @Override
+    public void dispose() {
+        view.clear();
+        selectedDocument = null;
+        for ( SelectableDocumentView selectableDocument : selectableDocuments ) {
+            beanManager.destroyBean( selectableDocument );
+        }
+        selectableDocuments.clear();
+    }
+
+    SelectableDocumentView makeSelectableDocument( final Path path ) {
+        final SelectableDocumentView selectableDocument = beanManager.lookupBean( SelectableDocumentView.class ).newInstance();
+        selectableDocument.setPath( path );
+        selectableDocument.setSelectDocumentCommand( () -> selectDocument( selectableDocument ) );
+        return selectableDocument;
+    }
+
+    void selectDocument( final SelectableDocumentView document ) {
+        this.selectedDocument = document;
+        if ( document == null ) {
+            view.enableOKButton( false );
+        } else {
+            view.enableOKButton( true );
+            for ( SelectableDocumentView d : selectableDocuments ) {
+                d.setSelected( d.getPath().equals( document.getPath() ) );
+            }
+        }
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupPresenter.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupPresenter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.popups;
+
+import java.util.List;
+
+import org.kie.workbench.common.widgets.metadata.client.KieMultipleDocumentEditorPresenter;
+import org.uberfire.backend.vfs.Path;
+
+/**
+ * Presenter definition for popup that allows Users to select a document from a list of additional documents available.
+ */
+public interface SelectDocumentPopupPresenter {
+
+    /**
+     * Sets the parent Presenter that is capable of opening documents. Cannot be null.
+     * See {@link KieMultipleDocumentEditorPresenter#onOpenDocumentInEditor(Path)}
+     * @param presenter
+     */
+    void setEditorPresenter( final KieMultipleDocumentEditorPresenter presenter );
+
+    /**
+     * Sets the documents to show in the View. Cannot be null.
+     * @param paths
+     */
+    void setDocuments( final List<Path> paths );
+
+    /**
+     * Shows the View.
+     */
+    void show();
+
+    /**
+     * Handles the User selecting a document to open in the editor.
+     */
+    void onOK();
+
+    /**
+     * Handles the User cancelling the operation.
+     */
+    void onCancel();
+
+    /**
+     * Disposes of the popup, clearing resources.
+     */
+    void dispose();
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupView.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupView.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.popups;
+
+import org.jboss.errai.common.client.api.IsElement;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.mvp.UberView;
+import org.uberfire.mvp.Command;
+
+/**
+ * View definition for popup that allows Users to select a document from a list of additional documents available.
+ */
+public interface SelectDocumentPopupView extends UberView<SelectDocumentPopupPresenter> {
+
+    /**
+     * View definition of a single document that can be selected.
+     */
+    interface SelectableDocumentView extends IsElement {
+
+        /**
+         * Gets the Path of the document.
+         * @return
+         */
+        Path getPath();
+
+        /**
+         * Sets the Path of the document. Cannot be null.
+         * @param path
+         */
+        void setPath( final Path path );
+
+        /**
+         * Sets the command to exeute when a document is selected in the View. Cannot be null.
+         * @param activateDocumentCommand
+         */
+        void setSelectDocumentCommand( final Command activateDocumentCommand );
+
+        /**
+         * Sets whether a document is selected in the View. Selected documents can be rendered differently.
+         * @param isSelected true if the document has been selected by the User.
+         */
+        void setSelected( final boolean isSelected );
+
+    }
+
+    /**
+     * Clears the View.
+     */
+    void clear();
+
+    /**
+     * Adds a document to the View. Cannot be null.
+     * @param document
+     */
+    void addDocument( final SelectableDocumentView document );
+
+    /**
+     * Enables the "OK" button.
+     * @param enabled true if the button is enabled.
+     */
+    void enableOKButton( final boolean enabled );
+
+    /**
+     * Shows the popup.
+     */
+    void show();
+
+    /**
+     * Hides the popup.
+     */
+    void hide();
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupViewImpl.html
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupViewImpl.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="well">
+
+  <style scoped>
+    .documents-container {
+      width: 100%;
+      height: 200px;
+      overflow: auto;
+      border: solid 1px #ddd;
+      padding: 5px 5px 5px 5px;
+    }
+
+  </style>
+
+
+  <span data-i18n-key="SelectDocument">Select a document to open in the editor.</span>
+
+  <div id="documents-container" class="documents-container">
+
+
+  </div>
+</div>

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupViewImpl.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.popups;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.Composite;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.Node;
+import org.jboss.errai.common.client.dom.NodeList;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.widgets.metadata.client.resources.i18n.KieMultipleDocumentEditorConstants;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKCancelButtons;
+
+@Dependent
+@Templated
+public class SelectDocumentPopupViewImpl extends Composite
+        implements SelectDocumentPopupView {
+
+    @DataField("documents-container")
+    Div documentsContainer;
+
+    private final BaseModal modal;
+    private final TranslationService translationService;
+
+    private final ModalFooterOKCancelButtons footer = new ModalFooterOKCancelButtons( this::onOK,
+                                                                                      this::onCancel );
+
+    private SelectDocumentPopupPresenter presenter;
+
+    @Inject
+    public SelectDocumentPopupViewImpl( final Div documentsContainer,
+                                        final TranslationService translationService ) {
+        super();
+        this.documentsContainer = documentsContainer;
+        this.translationService = translationService;
+        this.modal = new BaseModal();
+    }
+
+    @PostConstruct
+    void init() {
+        this.modal.setTitle( getSelectDocumentViewTitle() );
+        this.modal.setBody( this );
+        this.modal.add( footer );
+
+        this.modal.addHiddenHandler( ( e ) -> onHidden() );
+    }
+
+    @Override
+    public void init( final SelectDocumentPopupPresenter presenter ) {
+        this.presenter = presenter;
+    }
+
+    private String getSelectDocumentViewTitle() {
+        return translationService.format( KieMultipleDocumentEditorConstants.SelectDocumentPopupViewImpl_Title );
+    }
+
+    @Override
+    public void clear() {
+        final NodeList documents = documentsContainer.getChildNodes();
+        for ( int i = 0; i < documents.getLength(); i++ ) {
+            final Node document = documents.item( i );
+            documentsContainer.removeChild( document );
+        }
+    }
+
+    @Override
+    public void addDocument( final SelectableDocumentView document ) {
+        PortablePreconditions.checkNotNull( "document",
+                                            document );
+        documentsContainer.appendChild( document.getElement() );
+    }
+
+    @Override
+    public void enableOKButton( final boolean enabled ) {
+        footer.enableOkButton( enabled );
+    }
+
+    @Override
+    public void show() {
+        modal.show();
+    }
+
+    @Override
+    public void hide() {
+        modal.hide();
+    }
+
+    private void onOK() {
+        presenter.onOK();
+    }
+
+    private void onCancel() {
+        presenter.onCancel();
+    }
+
+    private void onHidden() {
+        presenter.dispose();
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectableDocumentImpl.html
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectableDocumentImpl.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div id="kie-selectable-document" class="kie-selectable-document-inactive">
+
+  <style scoped>
+    .kie-selectable-document-active {
+      background-color: cornflowerblue;
+    }
+
+    .kie-selectable-document-inactive {
+      background-color: lightblue;
+    }
+
+    .kie-selectable-document-base {
+      cursor: pointer;
+      padding: 2px 2px 2px 2px;
+      margin-bottom: 2px;
+      width: 100%;
+    }
+
+  </style>
+
+  <div id="kie-selectable-document-name" class="kie-selectable-document-base"></div>
+
+</div>

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectableDocumentImpl.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectableDocumentImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.popups;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.mvp.Command;
+
+@Dependent
+@Templated
+public class SelectableDocumentImpl implements SelectDocumentPopupView.SelectableDocumentView {
+
+    private static final String ACTIVE_CSS_CLASS = "kie-selectable-document-active";
+    private static final String INACTIVE_CSS_CLASS = "kie-selectable-document-inactive";
+
+    private Path path;
+    private Command activateDocumentCommand;
+
+    @Inject
+    @DataField("kie-selectable-document")
+    Div kieSelectableDocument;
+
+    @Inject
+    @DataField("kie-selectable-document-name")
+    Div kieSelectableDocumentName;
+
+    @Override
+    public HTMLElement getElement() {
+        return kieSelectableDocument;
+    }
+
+    @Override
+    public Path getPath() {
+        return this.path;
+    }
+
+    @Override
+    public void setPath( final Path path ) {
+        this.path = PortablePreconditions.checkNotNull( "path",
+                                                        path );
+        this.kieSelectableDocumentName.setInnerHTML( getSafeHtml( path.toURI() ).asString() );
+    }
+
+    private SafeHtml getSafeHtml( final String message ) {
+        final SafeHtmlBuilder shb = new SafeHtmlBuilder();
+        shb.appendEscaped( message );
+        return shb.toSafeHtml();
+    }
+
+    @Override
+    public void setSelectDocumentCommand( final Command activateDocumentCommand ) {
+        this.activateDocumentCommand = PortablePreconditions.checkNotNull( "activateDocumentCommand",
+                                                                           activateDocumentCommand );
+    }
+
+    @Override
+    public void setSelected( final boolean isSelected ) {
+        if ( isSelected ) {
+            kieSelectableDocument.setClassName( ACTIVE_CSS_CLASS );
+        } else {
+            kieSelectableDocument.setClassName( INACTIVE_CSS_CLASS );
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @EventHandler("kie-selectable-document-name")
+    public void onClickFileName( final ClickEvent e ) {
+        if ( this.activateDocumentCommand != null ) {
+            activateDocumentCommand.execute();
+        }
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/resources/i18n/KieMultipleDocumentEditorConstants.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/resources/i18n/KieMultipleDocumentEditorConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.resources.i18n;
+
+import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
+
+public class KieMultipleDocumentEditorConstants {
+
+    @TranslationKey(defaultValue = "")
+    public static final String NoDocuments_Title = "NoDocuments.Title";
+
+    @TranslationKey(defaultValue = "")
+    public static final String NoDocuments_Message = "NoDocuments.Message";
+
+    @TranslationKey(defaultValue = "")
+    public static final String SelectDocumentPopupViewImpl_Title = "SelectDocumentPopupViewImpl.Title";
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/resources/org/kie/workbench/common/widgets/metadata/client/resources/i18n/KieMultipleDocumentEditorConstants.properties
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/resources/org/kie/workbench/common/widgets/metadata/client/resources/i18n/KieMultipleDocumentEditorConstants.properties
@@ -14,3 +14,13 @@
 # limitations under the License.
 #
 SaveAllMenuViewImpl.saveAll=Save all
+
+RegisteredDocumentsMenuViewImpl.documents=Documents...
+RegisteredDocumentsMenuViewImpl.openDocument=Open...
+RegisteredDocumentsMenuViewImpl.saveDocuments=Save all
+
+NoDocuments.Title=No documents available.
+NoDocuments.Message=No additional documents found.
+
+SelectDocumentPopupViewImpl.Title=Available documents.
+SelectDocumentPopupViewImpl.SelectDocument=Select a document to open in the editor.

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/TestDocument.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/TestDocument.java
@@ -19,7 +19,7 @@ package org.kie.workbench.common.widgets.metadata.client;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.mvp.PlaceRequest;
 
-public class TestDocument implements KieMultipleDocumentEditor.KieDocument {
+public class TestDocument implements KieDocument {
 
     private String version;
     private ObservablePath latestPath;

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/TestMultipleDocumentEditor.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/TestMultipleDocumentEditor.java
@@ -16,7 +16,12 @@
 
 package org.kie.workbench.common.widgets.metadata.client;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.callbacks.Callback;
 import org.uberfire.mvp.PlaceRequest;
 
 public class TestMultipleDocumentEditor extends KieMultipleDocumentEditor<TestDocument> {
@@ -26,39 +31,50 @@ public class TestMultipleDocumentEditor extends KieMultipleDocumentEditor<TestDo
     }
 
     @Override
-    protected void loadDocument( final ObservablePath path,
-                                 final PlaceRequest placeRequest ) {
+    public void loadDocument( final ObservablePath path,
+                              final PlaceRequest placeRequest ) {
 
     }
 
     @Override
-    protected void refreshDocument( final TestDocument document ) {
+    public void refreshDocument( final TestDocument document ) {
 
     }
 
     @Override
-    protected void removeDocument( final TestDocument document ) {
+    public void removeDocument( final TestDocument document ) {
 
     }
 
     @Override
-    protected String getDocumentTitle( final TestDocument document ) {
+    public String getDocumentTitle( final TestDocument document ) {
         return null;
     }
 
     @Override
-    protected void onSourceTabSelected( final TestDocument document ) {
+    public void onSourceTabSelected( final TestDocument document ) {
 
     }
 
     @Override
-    protected void onValidate( final TestDocument document ) {
+    public void onValidate( final TestDocument document ) {
 
     }
 
     @Override
-    protected void onSave( final TestDocument document,
-                           String commitMessage ) {
+    public void onSave( final TestDocument document,
+                        final String commitMessage ) {
 
     }
+
+    @Override
+    public void getAvailableDocumentPaths( final Callback<List<Path>> callback ) {
+        callback.callback( Collections.<Path>emptyList() );
+    }
+
+    @Override
+    public void onOpenDocumentInEditor( final Path path ) {
+
+    }
+
 }

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuBuilderTest.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/menu/RegisteredDocumentsMenuBuilderTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.menu;
+
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.metadata.client.KieDocument;
+import org.kie.workbench.common.widgets.metadata.client.menu.RegisteredDocumentsMenuView.DocumentMenuItem;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+import org.uberfire.workbench.model.menu.MenuItem;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegisteredDocumentsMenuBuilderTest {
+
+    private RegisteredDocumentsMenuBuilder builder;
+
+    @Mock
+    private RegisteredDocumentsMenuView view;
+
+    @Mock
+    private SyncBeanDef<DocumentMenuItem> documentMenuItemBeanDef;
+
+    @Mock
+    private DocumentMenuItem documentMenuItem;
+
+    @Mock
+    private SyncBeanManager beanManager;
+
+    @Captor
+    private ArgumentCaptor<Command> removeDocumentCommandCaptor;
+
+    @Captor
+    private ArgumentCaptor<Command> activateDocumentCommandCaptor;
+
+    @Before
+    public void setup() {
+        final RegisteredDocumentsMenuBuilder wrapped = new RegisteredDocumentsMenuBuilder( view,
+                                                                                           beanManager );
+        wrapped.setup();
+
+        this.builder = spy( wrapped );
+
+        when( beanManager.lookupBean( eq( DocumentMenuItem.class ) ) ).thenReturn( documentMenuItemBeanDef );
+        when( documentMenuItemBeanDef.newInstance() ).thenReturn( documentMenuItem );
+    }
+
+    @Test
+    public void testEnable() {
+        final MenuItem mi = builder.build();
+        mi.setEnabled( true );
+
+        verify( view,
+                times( 1 ) ).setEnabled( eq( true ) );
+    }
+
+    @Test
+    public void testDisable() {
+        final MenuItem mi = builder.build();
+        mi.setEnabled( false );
+
+        verify( view,
+                times( 1 ) ).setEnabled( eq( false ) );
+    }
+
+    @Test
+    public void testOnOpenDocument_WithCommand() {
+        final Command command = mock( Command.class );
+        builder.setOpenDocumentCommand( command );
+        builder.onOpenDocument();
+
+        verify( command,
+                times( 1 ) ).execute();
+    }
+
+    @Test
+    public void testOnOpenDocument_WithoutCommand() {
+        try {
+            builder.onOpenDocument();
+        } catch ( NullPointerException npe ) {
+            fail( "Null Commands should be handled." );
+        }
+    }
+
+    @Test
+    public void testOnSaveDocuments_WithCommand() {
+        final Command command = mock( Command.class );
+        builder.setSaveDocumentsCommand( command );
+        builder.onSaveDocuments();
+
+        verify( command,
+                times( 1 ) ).execute();
+    }
+
+    @Test
+    public void testOnSaveDocuments_WithoutCommand() {
+        try {
+            builder.onSaveDocuments();
+        } catch ( NullPointerException npe ) {
+            fail( "Null Commands should be handled." );
+        }
+    }
+
+    @Test
+    public void testRegisterDocument() {
+        final KieDocument document = makeKieDocument();
+        builder.registerDocument( document );
+
+        verify( documentMenuItem,
+                times( 1 ) ).setName( "filename" );
+        verify( documentMenuItem,
+                times( 1 ) ).setRemoveDocumentCommand( removeDocumentCommandCaptor.capture() );
+        verify( documentMenuItem,
+                times( 1 ) ).setActivateDocumentCommand( activateDocumentCommandCaptor.capture() );
+        verify( view,
+                times( 1 ) ).addDocument( eq( documentMenuItem ) );
+
+        final Command removeDocumentCommand = removeDocumentCommandCaptor.getValue();
+        assertNotNull( removeDocumentCommand );
+        removeDocumentCommand.execute();
+
+        verify( builder,
+                times( 1 ) ).onRemoveDocument( document );
+
+        final Command activateDocumentCommand = activateDocumentCommandCaptor.getValue();
+        assertNotNull( activateDocumentCommand );
+        activateDocumentCommand.execute();
+
+        verify( builder,
+                times( 1 ) ).onActivateDocument( document );
+    }
+
+    @Test
+    public void testDereregisterDocument() {
+        final KieDocument document = makeKieDocument();
+        builder.registerDocument( document );
+
+        builder.deregisterDocument( document );
+
+        verify( view,
+                times( 1 ) ).deleteDocument( documentMenuItem );
+        verify( beanManager,
+                times( 1 ) ).destroyBean( documentMenuItem );
+    }
+
+    private KieDocument makeKieDocument() {
+        final KieDocument document = mock( KieDocument.class );
+        final ObservablePath currentPath = mock( ObservablePath.class );
+        when( document.getCurrentPath() ).thenReturn( currentPath );
+        when( currentPath.getFileName() ).thenReturn( "filename" );
+        return document;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnActivateDocument_WithCommand() {
+        final KieDocument document = makeKieDocument();
+        final ParameterizedCommand command = mock( ParameterizedCommand.class );
+        builder.setActivateDocumentCommand( command );
+        builder.onActivateDocument( document );
+
+        verify( command,
+                times( 1 ) ).execute( eq( document ) );
+    }
+
+    @Test
+    public void testOnActivateDocument_WithoutCommand() {
+        final KieDocument document = makeKieDocument();
+        try {
+            builder.onActivateDocument( document );
+        } catch ( NullPointerException npe ) {
+            fail( "Null Commands should be handled." );
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnRemoveDocument_WithCommand() {
+        final KieDocument document = makeKieDocument();
+        final ParameterizedCommand command = mock( ParameterizedCommand.class );
+        builder.setRemoveDocumentCommand( command );
+        builder.onRemoveDocument( document );
+
+        verify( command,
+                times( 1 ) ).execute( eq( document ) );
+    }
+
+    @Test
+    public void testOnRemoveDocument_WithoutCommand() {
+        final KieDocument document = makeKieDocument();
+        try {
+            builder.onRemoveDocument( document );
+        } catch ( NullPointerException npe ) {
+            fail( "Null Commands should be handled." );
+        }
+    }
+
+    @Test
+    public void testActivateDocument_active() {
+        final KieDocument document = makeKieDocument();
+        builder.registerDocument( document );
+        builder.activateDocument( document );
+
+        verify( documentMenuItem,
+                times( 1 ) ).setActive( eq( true ) );
+    }
+
+    @Test
+    public void testActivateDocument_inactive() {
+        final KieDocument document = makeKieDocument();
+        builder.registerDocument( document );
+        builder.activateDocument( mock( KieDocument.class ) );
+
+        verify( documentMenuItem,
+                times( 1 ) ).setActive( eq( false ) );
+    }
+
+    @Test
+    public void testDispose() {
+        final KieDocument document = makeKieDocument();
+        builder.registerDocument( document );
+
+        builder.dispose();
+
+        verify( view,
+                times( 1 ) ).clear();
+        verify( beanManager,
+                times( 1 ) ).destroyBean( documentMenuItem );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupTest.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/popups/SelectDocumentPopupTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client.popups;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.metadata.client.KieMultipleDocumentEditorPresenter;
+import org.kie.workbench.common.widgets.metadata.client.popups.SelectDocumentPopupView.SelectableDocumentView;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.mvp.Command;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SelectDocumentPopupTest {
+
+    @Mock
+    private SelectDocumentPopupView view;
+
+    @Mock
+    private SyncBeanManager beanManager;
+
+    @Mock
+    private SyncBeanDef<SelectableDocumentView> selectableDocumentBeanDef;
+
+    @Mock
+    private KieMultipleDocumentEditorPresenter editor;
+
+    private SelectDocumentPopupPresenter presenter;
+
+    @Before
+    public void setup() {
+        final SelectDocumentPopupPresenter wrapped = new SelectDocumentPopup( view,
+                                                                              beanManager );
+        wrapped.setEditorPresenter( editor );
+        presenter = spy( wrapped );
+
+    }
+
+    @Test
+    public void testSetDocuments() {
+        final SelectableDocumentView selectableDocumentBean = makeSelectableDocument( "default://p0/src/main/resources/dtable1.gdst" );
+
+        final List<Path> documents = new ArrayList<Path>() {{
+            add( selectableDocumentBean.getPath() );
+        }};
+
+        presenter.setDocuments( documents );
+
+        final ArgumentCaptor<SelectableDocumentView> selectableDocumentArgumentCaptor = ArgumentCaptor.forClass( SelectableDocumentView.class );
+
+        verify( presenter,
+                times( 1 ) ).dispose();
+        verify( view,
+                times( 1 ) ).addDocument( selectableDocumentArgumentCaptor.capture() );
+
+        final SelectableDocumentView selectableDocument = selectableDocumentArgumentCaptor.getValue();
+        assertNotNull( selectableDocument );
+        assertEquals( documents.get( 0 ).toURI(),
+                      selectableDocument.getPath().toURI() );
+
+        verify( view,
+                times( 1 ) ).enableOKButton( eq( false ) );
+    }
+
+    @Test
+    public void testShow() {
+        presenter.show();
+
+        verify( view,
+                times( 1 ) ).show();
+    }
+
+    @Test
+    public void testOnSelect() {
+        final SelectableDocumentView selectableDocumentBean1 = mock( SelectableDocumentView.class );
+        final SelectableDocumentView selectableDocumentBean2 = mock( SelectableDocumentView.class );
+        final Path documentPath1 = mock( Path.class );
+        final Path documentPath2 = mock( Path.class );
+
+        when( beanManager.lookupBean( eq( SelectableDocumentView.class ) ) ).thenReturn( selectableDocumentBeanDef );
+        when( selectableDocumentBeanDef.newInstance() ).thenReturn( selectableDocumentBean1 ).thenReturn( selectableDocumentBean2 );
+        when( selectableDocumentBean1.getPath() ).thenReturn( documentPath1 );
+        when( selectableDocumentBean2.getPath() ).thenReturn( documentPath2 );
+        when( documentPath1.toURI() ).thenReturn( "default://p0/src/main/resources/dtable1.gdst" );
+        when( documentPath2.toURI() ).thenReturn( "default://p0/src/main/resources/dtable2.gdst" );
+
+        final List<Path> documents = new ArrayList<Path>() {{
+            add( documentPath1 );
+            add( documentPath2 );
+        }};
+
+        final ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass( Command.class );
+
+        presenter.setDocuments( documents );
+
+        verify( selectableDocumentBean1,
+                times( 1 ) ).setSelectDocumentCommand( commandArgumentCaptor.capture() );
+
+        final Command command = commandArgumentCaptor.getValue();
+        assertNotNull( command );
+
+        command.execute();
+
+        verify( selectableDocumentBean1,
+                times( 1 ) ).setSelected( eq( true ) );
+        verify( selectableDocumentBean2,
+                times( 1 ) ).setSelected( eq( false ) );
+        verify( view,
+                times( 1 ) ).enableOKButton( eq( true ) );
+    }
+
+    @Test
+    public void testOnOK_WithSelection() {
+        final SelectableDocumentView selectableDocumentBean = makeSelectableDocument( "default://p0/src/main/resources/dtable1.gdst" );
+
+        final List<Path> documents = new ArrayList<Path>() {{
+            add( selectableDocumentBean.getPath() );
+        }};
+
+        final ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass( Command.class );
+
+        presenter.setDocuments( documents );
+
+        verify( presenter,
+                times( 1 ) ).dispose();
+        verify( selectableDocumentBean,
+                times( 1 ) ).setSelectDocumentCommand( commandArgumentCaptor.capture() );
+
+        final Command command = commandArgumentCaptor.getValue();
+        command.execute();
+
+        presenter.onOK();
+
+        verify( editor,
+                times( 1 ) ).onOpenDocumentInEditor( eq( selectableDocumentBean.getPath() ) );
+        verify( view,
+                times( 1 ) ).hide();
+        verify( presenter,
+                times( 2 ) ).dispose();
+    }
+
+    @Test
+    public void testOnOK_WithoutSelection() {
+        final SelectableDocumentView selectableDocumentBean = makeSelectableDocument( "default://p0/src/main/resources/dtable1.gdst" );
+
+        final List<Path> documents = new ArrayList<Path>() {{
+            add( selectableDocumentBean.getPath() );
+        }};
+
+        presenter.setDocuments( documents );
+
+        verify( presenter,
+                times( 1 ) ).dispose();
+
+        presenter.onOK();
+
+        verify( editor,
+                never() ).onOpenDocumentInEditor( any( Path.class ) );
+        verify( view,
+                times( 1 ) ).hide();
+        verify( presenter,
+                times( 2 ) ).dispose();
+    }
+
+    @Test
+    public void testOnCancel() {
+        presenter.onCancel();
+
+        verify( view,
+                times( 1 ) ).hide();
+        verify( presenter,
+                times( 1 ) ).dispose();
+    }
+
+    @Test
+    public void testDispose() {
+        final SelectableDocumentView selectableDocumentBean = makeSelectableDocument( "default://p0/src/main/resources/dtable1.gdst" );
+
+        final List<Path> documents = new ArrayList<Path>() {{
+            add( selectableDocumentBean.getPath() );
+        }};
+
+        presenter.setDocuments( documents );
+
+        verify( view,
+                times( 1 ) ).clear();
+
+        presenter.dispose();
+
+        verify( view,
+                times( 2 ) ).clear();
+        verify( beanManager,
+                times( 1 ) ).destroyBean( any( SelectableDocumentView.class ) );
+    }
+
+    private SelectableDocumentView makeSelectableDocument( final String uri ) {
+        final SelectableDocumentView selectableDocumentBean = mock( SelectableDocumentView.class );
+        final Path documentPath = mock( Path.class );
+
+        when( beanManager.lookupBean( eq( SelectableDocumentView.class ) ) ).thenReturn( selectableDocumentBeanDef );
+        when( selectableDocumentBeanDef.newInstance() ).thenReturn( selectableDocumentBean );
+        when( selectableDocumentBean.getPath() ).thenReturn( documentPath );
+        when( documentPath.toURI() ).thenReturn( uri );
+
+        return selectableDocumentBean;
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2507

This PR refactors some ```abstract``` methods from classes to methods on ```interfaces``` and creates a couple of new views to (1) list the documents that are open (and support the user clicking on documents in the list to select them in the editor), (2) allow the user to open other existing documents in the editor.