### PR TITLE
GUVNOR-2548: Guided Decision Table Editor: BasicFileMenuBuilderImpl: Support overriding default lock-sync behaviour

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/menu/FileMenuBuilder.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/menu/FileMenuBuilder.java
@@ -17,12 +17,13 @@ package org.kie.workbench.common.widgets.client.menu;
 
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
+import org.uberfire.ext.editor.commons.client.menu.HasLockSyncMenuStateHelper;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
-public interface FileMenuBuilder {
+public interface FileMenuBuilder extends HasLockSyncMenuStateHelper {
 
     FileMenuBuilder addSave( final MenuItem menuItem );
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/menu/FileMenuBuilderImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/menu/FileMenuBuilderImpl.java
@@ -170,4 +170,10 @@ public class
 
         return this;
     }
+
+    @Override
+    public void setLockSyncMenuStateHelper( final LockSyncMenuStateHelper lockSyncMenuStateHelper ) {
+        menuBuilder.setLockSyncMenuStateHelper( lockSyncMenuStateHelper );
+    }
+
 }

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditor.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditor.java
@@ -452,6 +452,7 @@ public abstract class KieMultipleDocumentEditor<D extends KieDocument> implement
      */
     @Override
     public void makeMenuBar() {
+        this.fileMenuBuilder.setLockSyncMenuStateHelper( new KieMultipleDocumentEditorLockSyncHelper( this ) );
         this.menus = fileMenuBuilder
                 .addSave( getSaveMenuItem() )
                 .addCopy( () -> getActiveDocument().getCurrentPath(),

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorLockSyncHelper.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorLockSyncHelper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client;
+
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.ext.editor.commons.client.menu.HasLockSyncMenuStateHelper;
+import org.uberfire.workbench.model.menu.MenuItem;
+
+/**
+ * Specialized {@link HasLockSyncMenuStateHelper.LockSyncMenuStateHelper} that only enables/disables {@link MenuItem}
+ * if the lock relates to the "active document" (see {@link KieMultipleDocumentEditor#getActiveDocument()}
+ */
+public class KieMultipleDocumentEditorLockSyncHelper extends HasLockSyncMenuStateHelper.BasicLockSyncMenuStateHelper {
+
+    private KieMultipleDocumentEditor editor;
+
+    public KieMultipleDocumentEditorLockSyncHelper( final KieMultipleDocumentEditor editor ) {
+        this.editor = PortablePreconditions.checkNotNull( "editor",
+                                                          editor );
+    }
+
+    @Override
+    public Operation enable( final Path file,
+                             final boolean isLocked,
+                             final boolean isLockedByCurrentUser ) {
+        final KieDocument activeDocument = editor.getActiveDocument();
+        if ( activeDocument == null || !activeDocument.getCurrentPath().equals( file ) ) {
+            return Operation.VETO;
+        }
+        return super.enable( file,
+                             isLocked,
+                             isLockedByCurrentUser );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorLockSyncHelperTest.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorLockSyncHelperTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.metadata.client;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.menu.HasLockSyncMenuStateHelper.LockSyncMenuStateHelper.Operation;
+import org.uberfire.mvp.PlaceRequest;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KieMultipleDocumentEditorLockSyncHelperTest {
+
+    @Mock
+    private ObservablePath path;
+
+    @Mock
+    private PlaceRequest placeRequest;
+
+    @Mock
+    private KieMultipleDocumentEditor<TestDocument> editor;
+
+    @Mock
+    private TestDocument document;
+
+    private KieMultipleDocumentEditorLockSyncHelper lockSyncHelper;
+
+    @Before
+    public void setup() {
+        this.lockSyncHelper = new KieMultipleDocumentEditorLockSyncHelper( editor );
+    }
+
+    @Test
+    public void testLocked_NullActiveDocument() {
+        when( editor.getActiveDocument() ).thenReturn( null );
+        when( document.getCurrentPath() ).thenReturn( path );
+
+        final Operation op = lockSyncHelper.enable( mock( Path.class ),
+                                                    true,
+                                                    false );
+        assertEquals( Operation.VETO,
+                      op );
+    }
+
+    @Test
+    public void testLocked_NotActiveDocument() {
+        when( editor.getActiveDocument() ).thenReturn( document );
+        when( document.getCurrentPath() ).thenReturn( path );
+
+        final Operation op = lockSyncHelper.enable( mock( ObservablePath.class ),
+                                                    true,
+                                                    false );
+        assertEquals( Operation.VETO,
+                      op );
+    }
+
+    @Test
+    public void testLocked_ActiveDocument() {
+        when( editor.getActiveDocument() ).thenReturn( document );
+        when( document.getCurrentPath() ).thenReturn( path );
+
+        final Operation op = lockSyncHelper.enable( path,
+                                                    true,
+                                                    false );
+        assertEquals( Operation.DISABLE,
+                      op );
+    }
+
+    @Test
+    public void testLockedByCurrentUser_ActiveDocument() {
+        when( editor.getActiveDocument() ).thenReturn( document );
+        when( document.getCurrentPath() ).thenReturn( path );
+
+        final Operation op = lockSyncHelper.enable( path,
+                                                    true,
+                                                    true );
+        assertEquals( Operation.ENABLE,
+                      op );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2548

This PR provides an implementation of ```LockSyncMenuStateHelper``` that only applies changes to ```MenuItem``` enabled state if change in lock is associated with the "active document".