### PR TITLE
RHBPMS-3997: [GSS](6.3.x) Project dependencies are not retained in BPM Suite 6.3.0

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager.java
@@ -56,7 +56,7 @@ public class EnhancedDependenciesManager {
         this.originalSetOfDependencies = pom.getDependencies();
         this.enhancedDependencies.clear();
 
-        addToQueue( originalSetOfDependencies.getGavs( "compile" ) );
+        addToQueue( originalSetOfDependencies.getCompileScopedGavs() );
 
         this.callback = callback;
     }


### PR DESCRIPTION
In fact, the dependencies were being saved correctly. However, in the dependency page load, a filter was removing the dependencies that had scope different from "compile". As "compile" is the default scope, this PR makes dependencies without scope be handled as a compile dependency.