### PR TITLE
PLANNER-618 Workbench: Use org.jboss.errai.ioc.client.api.ManagedInstance instead of BeanManager where possible

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/DomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/DomainHandler.java
@@ -17,7 +17,6 @@
 package org.kie.workbench.common.screens.datamodeller.client.handlers;
 
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.DomainEditor;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
 
 public interface DomainHandler {
@@ -26,11 +25,7 @@ public interface DomainHandler {
 
     int getPriority();
 
-    DomainEditor getDomainEditor( boolean newInstance );
-
     ResourceOptions getResourceOptions( boolean newInstance );
-
-    boolean validateCommand( DataModelCommand command );
 
     void postCommandProcessing( DataModelCommand command );
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/advanceddomain/AdvancedDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/advanceddomain/AdvancedDomainHandler.java
@@ -18,11 +18,8 @@ package org.kie.workbench.common.screens.datamodeller.client.handlers.advanceddo
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.jboss.errai.ioc.client.container.IOC;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.advanceddomain.AdvancedDomainEditor;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.DomainEditor;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
 
 @ApplicationScoped
@@ -42,24 +39,9 @@ public class AdvancedDomainHandler implements DomainHandler {
     }
 
     @Override
-    public DomainEditor getDomainEditor( boolean newInstance ) {
-        //TODO, currently a new instance is always created. Likely the singleton option will be added when
-        //we add the UF tool windows.
-        AdvancedDomainEditor domainEditor = IOC.getBeanManager().lookupBean( AdvancedDomainEditor.class ).newInstance();
-        domainEditor.setHandler( this );
-        return domainEditor;
-    }
-
-    @Override
     public ResourceOptions getResourceOptions( boolean newInstance ) {
         //this domain has no special options at resource creation time.
         return null;
-    }
-
-    @Override
-    public boolean validateCommand( DataModelCommand command ) {
-        //cross domain validation not yet implemented
-        return true;
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/droolsdomain/DroolsDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/droolsdomain/DroolsDomainHandler.java
@@ -18,12 +18,9 @@ package org.kie.workbench.common.screens.datamodeller.client.handlers.droolsdoma
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.jboss.errai.ioc.client.container.IOC;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.DomainEditor;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.droolsdomain.DroolsDomainEditor;
 
 @ApplicationScoped
 public class DroolsDomainHandler implements DomainHandler {
@@ -42,24 +39,9 @@ public class DroolsDomainHandler implements DomainHandler {
     }
 
     @Override
-    public DomainEditor getDomainEditor( boolean newInstance ) {
-        //TODO, currently a new instance is always created. Likely the singleton option will be added when
-        //we add the UF tool windows.
-        DroolsDomainEditor domainEditor = IOC.getBeanManager().lookupBean( DroolsDomainEditor.class ).newInstance();
-        domainEditor.setHandler( this );
-        return domainEditor;
-    }
-
-    @Override
     public ResourceOptions getResourceOptions( boolean newInstance ) {
         //this domain has no special options at resource creation time.
         return null;
-    }
-
-    @Override
-    public boolean validateCommand( DataModelCommand command ) {
-        //cross domain validation not yet implemented
-        return true;
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/jpadomain/JPADomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/jpadomain/JPADomainHandler.java
@@ -20,16 +20,13 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import org.jboss.errai.ioc.client.container.IOC;
 import org.kie.workbench.common.screens.datamodeller.client.command.AddPropertyCommand;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.command.FieldTypeChangeCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.jpadomain.command.AdjustFieldDefaultRelationsCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.jpadomain.command.JPACommandBuilder;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.DomainEditor;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.jpadomain.JPADomainEditor;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.jpadomain.options.JPANewResourceOptions;
 import org.kie.workbench.common.screens.datamodeller.model.jpadomain.JPADomainAnnotations;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
@@ -58,22 +55,9 @@ public class JPADomainHandler implements DomainHandler {
     }
 
     @Override
-    public DomainEditor getDomainEditor( boolean newInstance ) {
-        JPADomainEditor domainEditor = IOC.getBeanManager().lookupBean( JPADomainEditor.class ).newInstance();
-        domainEditor.setHandler( this );
-        return domainEditor;
-    }
-
-    @Override
     public ResourceOptions getResourceOptions( boolean newInstance ) {
         //currently same instance is always returned, since file handlers are all ApplicationScoped
         return newResourceOptions.get();
-    }
-
-    @Override
-    public boolean validateCommand( DataModelCommand command ) {
-        //cross domain validation not yet implemented
-        return true;
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/maindomain/MainDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/maindomain/MainDomainHandler.java
@@ -18,12 +18,9 @@ package org.kie.workbench.common.screens.datamodeller.client.handlers.maindomain
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.jboss.errai.ioc.client.container.IOC;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.DomainEditor;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.client.widgets.maindomain.MainDomainEditor;
 
 @ApplicationScoped
 public class MainDomainHandler implements DomainHandler {
@@ -42,24 +39,9 @@ public class MainDomainHandler implements DomainHandler {
     }
 
     @Override
-    public DomainEditor getDomainEditor( boolean newInstance ) {
-        //TODO, currently a new instance is always created. Likely the singleton option will be added when
-        //we add the UF tool windows.
-        MainDomainEditor domainEditor = IOC.getBeanManager().lookupBean( MainDomainEditor.class ).newInstance();
-        domainEditor.setHandler( this );
-        return domainEditor;
-    }
-
-    @Override
     public ResourceOptions getResourceOptions( boolean newInstance ) {
         //this domain has no special options at resource creation time.
         return null;
-    }
-
-    @Override
-    public boolean validateCommand( DataModelCommand command ) {
-        //cross domain validation not yet implemented
-        return true;
     }
 
     @Override


### PR DESCRIPTION
Removes unused methods from `DomainHandler` class hierarchy.