### PR TITLE
GUVNOR-2621: DataModelOracle: Does not handle annotations with member properties of type Class e.g. @XmlType

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/pom.xml
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/pom.xml
@@ -101,7 +101,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-config</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.workbench.services</groupId>

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/AnnotationUtils.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/main/java/org/kie/workbench/common/services/datamodel/backend/server/builder/util/AnnotationUtils.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.jboss.errai.config.rebind.EnvUtil;
+
 /**
  * Utilities for handling Java Annotations
  */
@@ -40,6 +42,14 @@ public class AnnotationUtils {
         if ( annotation != null ) {
             try {
                 value = annotation.annotationType().getMethod( attributeName ).invoke( annotation );
+
+                final Class valueType = value.getClass();
+                final Class componentType = valueType.getComponentType();
+                final Class portableType = componentType != null ? componentType : valueType;
+                if ( !EnvUtil.isPortableType( portableType ) ) {
+                    value = value.toString();
+                }
+
             } catch ( Exception ex ) {
                 //Swallow
             }
@@ -77,7 +87,8 @@ public class AnnotationUtils {
      * @param inherited
      * @return
      */
-    public static Set<org.drools.workbench.models.datamodel.oracle.Annotation> getFieldAnnotations( Field field, boolean inherited ) {
+    public static Set<org.drools.workbench.models.datamodel.oracle.Annotation> getFieldAnnotations( Field field,
+                                                                                                    boolean inherited ) {
 
         if ( field == null ) {
             return Collections.EMPTY_SET;
@@ -86,13 +97,13 @@ public class AnnotationUtils {
         return getAnnotations( field.getDeclaredAnnotations(), inherited );
     }
 
-
-    private static Set<org.drools.workbench.models.datamodel.oracle.Annotation> getAnnotations( final java.lang.annotation.Annotation[] annotations, boolean checkInheritance ) {
+    private static Set<org.drools.workbench.models.datamodel.oracle.Annotation> getAnnotations( final java.lang.annotation.Annotation[] annotations,
+                                                                                                boolean checkInheritance ) {
         final Set<org.drools.workbench.models.datamodel.oracle.Annotation> fieldAnnotations = new LinkedHashSet<>();
         for ( java.lang.annotation.Annotation a : annotations ) {
 
             if ( checkInheritance ) {
-                if( !a.annotationType().isAnnotationPresent( Inherited.class ) ) {
+                if ( !a.annotationType().isAnnotationPresent( Inherited.class ) ) {
                     continue;
                 }
             }

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelFactAnnotationsTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/ProjectDataModelFactAnnotationsTest.java
@@ -21,10 +21,10 @@ import org.drools.workbench.models.commons.backend.oracle.ProjectDataModelOracle
 import org.drools.workbench.models.datamodel.oracle.Annotation;
 import org.drools.workbench.models.datamodel.oracle.TypeSource;
 import org.junit.Test;
-import org.kie.api.definition.type.Role;
 import org.kie.workbench.common.services.datamodel.backend.server.builder.projects.ClassFactBuilder;
 import org.kie.workbench.common.services.datamodel.backend.server.builder.projects.ProjectDataModelOracleBuilder;
 import org.kie.workbench.common.services.datamodel.backend.server.testclasses.Product;
+import org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations.JAXBSmurf;
 import org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations.RoleSmurf;
 import org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations.Smurf;
 
@@ -114,8 +114,53 @@ public class ProjectDataModelFactAnnotationsTest {
         final Annotation annotation = annotations.iterator().next();
         assertEquals( "org.kie.api.definition.type.Role",
                       annotation.getQualifiedTypeName() );
-        assertEquals( Role.Type.EVENT,
+        assertEquals( "EVENT",
                       annotation.getParameters().get( "value" ) );
+    }
+
+    @Test
+    public void annotationsWithMemberOfTypeClass() throws Exception {
+        final ProjectDataModelOracleBuilder builder = ProjectDataModelOracleBuilder.newProjectOracleBuilder();
+        final ProjectDataModelOracleImpl oracle = new ProjectDataModelOracleImpl();
+
+        final ClassFactBuilder cb = new ClassFactBuilder( builder,
+                                                          JAXBSmurf.class,
+                                                          false,
+                                                          TypeSource.JAVA_PROJECT );
+        cb.build( oracle );
+
+        assertEquals( 1,
+                      oracle.getProjectModelFields().size() );
+        assertContains( "org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations.JAXBSmurf",
+                        oracle.getProjectModelFields().keySet() );
+
+        final Set<Annotation> annotations = oracle.getProjectTypeAnnotations().get( "org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations.JAXBSmurf" );
+        assertNotNull( annotations );
+        assertEquals( 1,
+                      annotations.size() );
+
+        final Annotation annotation = annotations.iterator().next();
+        assertEquals( "javax.xml.bind.annotation.XmlType",
+                      annotation.getQualifiedTypeName() );
+        assertEquals( 5,
+                      annotation.getParameters().size() );
+        assertEquals( "smurf-namespace",
+                      annotation.getParameters().get( "namespace" ) );
+        assertEquals( "smurf-xsd",
+                      annotation.getParameters().get( "name" ) );
+        assertArraysEqual( new String[]{ "name", "colour" },
+                           (String[]) annotation.getParameters().get( "propOrder" ) );
+        assertTrue( annotation.getParameters().get( "factoryClass" ).toString().contains( "org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations.JAXBSmurfFactory" ) );
+    }
+
+    private static void assertArraysEqual( final String[] expected,
+                                           final String[] actual ) {
+        assertEquals( expected.length,
+                      actual.length );
+        for ( int i = 0; i < expected.length; i++ ) {
+            assertEquals( expected[ i ],
+                          actual[ i ] );
+        }
     }
 
 }

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/testclasses/annotations/JAXBSmurf.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/testclasses/annotations/JAXBSmurf.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(factoryClass = JAXBSmurfFactory.class, factoryMethod = "makeSmurf", name = "smurf-xsd", namespace = "smurf-namespace", propOrder = { "name", "colour" })
+public class JAXBSmurf {
+
+    private String name;
+    private String colour;
+
+    public String getColour() {
+        return colour;
+    }
+
+    public void setColour( String colour ) {
+        this.colour = colour;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName( String name ) {
+        this.name = name;
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/testclasses/annotations/JAXBSmurfFactory.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/testclasses/annotations/JAXBSmurfFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.datamodel.backend.server.testclasses.annotations;
+
+public class JAXBSmurfFactory {
+
+    JAXBSmurf makeSmurf() {
+        return new JAXBSmurf();
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelFactAnnotationsTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/datamodel/PackageDataModelFactAnnotationsTest.java
@@ -203,7 +203,7 @@ public class PackageDataModelFactAnnotationsTest {
                                            final Annotation annotation = annotations.iterator().next();
                                            assertEquals( "org.kie.api.definition.type.Role",
                                                          annotation.getQualifiedTypeName() );
-                                           assertEquals( Role.Type.EVENT,
+                                           assertEquals( "EVENT",
                                                          annotation.getParameters().get( "value" ) );
                                        }
                                    } );


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2621

The solution contained in this PR is to use the ```toString()``` representation of any non-portable values.

```Class``` on the client has very little use, as it cannot be instantiated. I tested with ```drools-wb-webapp``` and Data Modeller and rules (with, for example, EVENTS) continue to work fine.. All tests pass (I had to change two assertions from ``` Role.Type.EVENT``` to ```"EVENT"``` however we do not use this to determine whether a Type is an event).