### PR TITLE
DROOLS-1235 MBean naming rework

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/Builder.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/builder/Builder.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
@@ -528,7 +529,7 @@ public class Builder {
             final KieModule kieModule = kieBuilder.getKieModule();
             final ReleaseId releaseId = kieModule.getReleaseId();
             final org.drools.compiler.kie.builder.impl.KieProject kieProject = new KieModuleKieProject( (InternalKieModule) kieBuilder.getKieModule(), null );
-            final KieContainer kieContainer = new KieContainerImpl( kieProject,
+            final KieContainer kieContainer = new KieContainerImpl( UUID.randomUUID() + "_bz1202551" , kieProject,
                                                                     KieServices.Factory.get().getRepository(),
                                                                     releaseId );
             return kieContainer;


### PR DESCRIPTION
* reflecting internal api / implementation of KieContainerImpl
constructor change, requiring a container Id (normally a new
KieContainerImpl is called via KieServices so transparently, but in this
case is explicitly required manual management).

ref: https://github.com/droolsjbpm/drools/pull/866/files#diff-e543bc3de6e92024156f45b7159043d0L106
ref: droolsjbpm/drools#866