### PR TITLE
PLANNER-630 Workbench: Solver configuration names contain redundant 'solver' suffix

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/utils/Utils.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/utils/Utils.java
@@ -308,10 +308,10 @@ public class Utils {
      * @param fileName
      * @return
      */
-    public static String getBaseFileName( final String fileName ) {
-        final int dotIndex = fileName.lastIndexOf( "." );
-        return ( dotIndex > 0 ? fileName.substring( 0,
-                                                    dotIndex ) : fileName );
+    public static String getBaseFileName( final String fileName, final String suffix ) {
+        final int suffixIndex = fileName.lastIndexOf( "." + suffix );
+        return ( suffixIndex > 0 ? fileName.substring( 0,
+                                                    suffixIndex ) : fileName );
     }
 
 }

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/main/java/org/kie/workbench/common/screens/explorer/client/widgets/business/BusinessViewWidget.java
@@ -278,7 +278,7 @@ public class BusinessViewWidget extends BaseViewImpl implements View {
                                       final FolderItem folderItem ) {
         String _fileName = folderItem.getFileName();
         if ( !( resourceType instanceof AnyResourceType ) ) {
-            _fileName = Utils.getBaseFileName( _fileName );
+            _fileName = Utils.getBaseFileName( _fileName, resourceType.getSuffix() );
         }
         _fileName = _fileName.replaceAll( " ", "\u00a0" );
         final String fileName = _fileName;

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/utils/UtilsTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-client/src/test/java/org/kie/workbench/common/screens/explorer/client/utils/UtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.explorer.client.utils;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.client.workbench.type.ClientResourceType;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class UtilsTest {
+
+    @Mock
+    private ClientResourceType clientResourceType;
+
+    @Test
+    public void getBaseFileNameSimpleExtension() {
+        when( clientResourceType.getSuffix() ).thenReturn( "xml" );
+        String result = Utils.getBaseFileName( "filename.xml", clientResourceType.getSuffix() );
+        assertEquals( "filename", result );
+    }
+
+    @Test
+    public void getBaseFileNameComplexExtension() {
+        when( clientResourceType.getSuffix() ).thenReturn( "suffix.xml" );
+        String result = Utils.getBaseFileName( "filename.suffix.xml", clientResourceType.getSuffix() );
+        assertEquals( "filename", result );
+    }
+}


### PR DESCRIPTION
Use suffix of given resource type instead of determining it by the last occurrence of '.' character. This is motivated by the fact that solver configuration filenames use 'solver.xml' suffix, which leads to undesired behavior.