### PR TITLE
RHBRMS-349: New Item Menu: No Project selected, all items enabled after Perspective reset

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenu.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenu.java
@@ -21,63 +21,31 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.GWT;
 import org.guvnor.common.services.project.context.ProjectContext;
 import org.guvnor.common.services.project.context.ProjectContextChangeEvent;
-import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
-import org.jboss.errai.common.client.api.RemoteCallback;
-import org.kie.workbench.common.screens.projecteditor.client.validation.ProjectNameValidator;
 import org.kie.workbench.common.services.shared.project.KieProject;
-import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.kie.workbench.common.widgets.client.resources.i18n.ToolsMenuConstants;
-import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.PlaceManager;
-import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
-import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
-import org.uberfire.ext.editor.commons.client.file.popups.CopyPopUpPresenter;
-import org.uberfire.ext.editor.commons.client.file.popups.DeletePopUpPresenter;
-import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
-import org.uberfire.ext.editor.commons.service.CopyService;
-import org.uberfire.ext.editor.commons.service.DeleteService;
-import org.uberfire.ext.editor.commons.service.RenameService;
 import org.uberfire.mvp.Command;
-import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 
 @ApplicationScoped
 public class ProjectMenu {
 
-    @Inject
     private PlaceManager placeManager;
+    private ProjectContext context;
+
+    public ProjectMenu() {
+        //Zero argument constructor for CDI proxies
+    }
 
     @Inject
-    protected Caller<KieProjectService> projectService;
-
-    @Inject
-    protected Caller<RenameService> renameService;
-
-    @Inject
-    protected Caller<DeleteService> deleteService;
-
-    @Inject
-    protected Caller<CopyService> copyService;
-
-    @Inject
-    protected CopyPopUpPresenter copyPopUpPresenter;
-
-    @Inject
-    protected RenamePopUpPresenter renamePopUpPresenter;
-
-    @Inject
-    protected DeletePopUpPresenter deletePopUpPresenter;
-
-    @Inject
-    protected ProjectContext context;
-
-    @Inject
-    protected ProjectNameValidator projectNameValidator;
+    public ProjectMenu( final PlaceManager placeManager,
+                        final ProjectContext context ) {
+        this.placeManager = placeManager;
+        this.context = context;
+    }
 
     private MenuItem projectScreen = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.ProjectEditor() ).respondsWith(
             new Command() {
@@ -95,97 +63,13 @@ public class ProjectMenu {
                 }
             } ).endMenu().build().getItems().get( 0 );
 
-    private MenuItem copyProject = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.CopyProject() ).respondsWith(
-            new Command() {
-                @Override
-                public void execute() {
-                    final Path path = context.getActiveProject().getRootPath();
-                    copyPopUpPresenter.show( path,
-                                             projectNameValidator,
-                                             new CommandWithFileNameAndCommitMessage() {
-                                                 @Override
-                                                 public void execute( FileNameAndCommitMessage payload ) {
-                                                     copyService.call( new RemoteCallback<Void>() {
-
-                                                         @Override
-                                                         public void callback( final Void o ) {
-                                                             copyPopUpPresenter.getView().hide();
-                                                         }
-                                                     }, new ErrorCallback<Void>() {
-
-                                                         @Override
-                                                         public boolean error( final Void o,
-                                                                               final Throwable throwable ) {
-                                                             copyPopUpPresenter.getView().hide();
-                                                             return false;
-                                                         }
-                                                     } ).copy( path,
-                                                               payload.getNewFileName(),
-                                                               payload.getCommitMessage() );
-                                                 }
-                                             } );
-                }
-            } ).endMenu().build().getItems().get( 0 );
-
-    private MenuItem renameProject = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.RenameProject() ).respondsWith(
-            new Command() {
-                @Override
-                public void execute() {
-                    final Path path = context.getActiveProject().getRootPath();
-                    renamePopUpPresenter.show( path,
-                                               projectNameValidator,
-                                               new CommandWithFileNameAndCommitMessage() {
-                                                   @Override
-                                                   public void execute( FileNameAndCommitMessage payload ) {
-                                                       renameService.call( new RemoteCallback<Void>() {
-
-                                                           @Override
-                                                           public void callback( final Void o ) {
-                                                               renamePopUpPresenter.getView().hide();
-                                                           }
-                                                       }, new ErrorCallback<Void>() {
-
-                                                           @Override
-                                                           public boolean error( final Void o,
-                                                                                 final Throwable throwable ) {
-                                                               renamePopUpPresenter.getView().hide();
-                                                               return false;
-                                                           }
-                                                       } ).rename( path,
-                                                                   payload.getNewFileName(),
-                                                                   payload.getCommitMessage() );
-                                                   }
-                                               } );
-
-                }
-            } ).endMenu().build().getItems().get( 0 );
-
-    private MenuItem removeProject = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.RemoveProject() ).respondsWith(
-            new Command() {
-                @Override
-                public void execute() {
-                    deletePopUpPresenter.show( new ParameterizedCommand<String>() {
-                        @Override
-                        public void execute( String payload ) {
-                            deleteService.call().delete(
-                                    context.getActiveProject().getRootPath(),
-                                    payload );
-                        }
-                    } );
-
-                }
-            } ).endMenu().build().getItems().get( 0 );
-
     public List<MenuItem> getMenuItems() {
+        enableToolsMenuItems( (KieProject) context.getActiveProject() );
+
         ArrayList<MenuItem> menuItems = new ArrayList<MenuItem>();
 
         menuItems.add( projectScreen );
-
         menuItems.add( projectStructureScreen );
-
-//        menuItems.add(removeProject);
-//        menuItems.add(renameProject);
-//        menuItems.add(copyProject);
 
         return menuItems;
     }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenuTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenuTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.menu;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.context.ProjectContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.mockito.Mock;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.workbench.model.menu.MenuItem;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ProjectMenuTest {
+
+    private ProjectMenu menu;
+
+    @Mock
+    private PlaceManager placeManager;
+
+    @Mock
+    private ProjectContext projectContext;
+
+    @Before
+    public void setup() {
+        menu = new ProjectMenu( placeManager,
+                                projectContext );
+    }
+
+    @Test
+    public void getMenuItemsSynchronizesDisabledState() {
+        final List<MenuItem> menus = menu.getMenuItems();
+
+        assertFalse( menus.get( 0 ).isEnabled() );
+        assertTrue( menus.get( 1 ).isEnabled() );
+    }
+
+    @Test
+    public void getMenuItemsSynchronizesEnabledState() {
+        when( projectContext.getActiveProject() ).thenReturn( mock( KieProject.class ) );
+
+        final List<MenuItem> menus = menu.getMenuItems();
+
+        assertTrue( menus.get( 0 ).isEnabled() );
+        assertTrue( menus.get( 1 ).isEnabled() );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenu.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenu.java
@@ -60,6 +60,7 @@ public class NewResourcesMenu
         this.newResourcePresenter = newResourcePresenter;
         projectContext.addChangeHandler( this );
     }
+
     private MenuItem projectMenuItem;
 
     @PostConstruct
@@ -82,7 +83,7 @@ public class NewResourcesMenu
 
     private void addMenuItem( final NewResourceHandler newResourceHandler ) {
 
-        if ( newResourceHandler.canCreate( ) ) {
+        if ( newResourceHandler.canCreate() ) {
 
             final MenuItem menuItem = getMenuItem( newResourceHandler );
 
@@ -134,10 +135,14 @@ public class NewResourcesMenu
     }
 
     public List<MenuItem> getMenuItems() {
+        enableMenuItemsForContext();
+
         return items;
     }
 
     public List<MenuItem> getMenuItemsWithoutProject() {
+        enableMenuItemsForContext();
+
         if ( projectMenuItem != null && items.contains( projectMenuItem ) ) {
             return items.subList( 1,
                                   items.size() );
@@ -148,6 +153,10 @@ public class NewResourcesMenu
 
     @Override
     public void onChange() {
+        enableMenuItemsForContext();
+    }
+
+    void enableMenuItemsForContext() {
         for ( Map.Entry<NewResourceHandler, MenuItem> entry : this.newResourceHandlers.entrySet() ) {
             final NewResourceHandler handler = entry.getKey();
             final MenuItem menuItem = entry.getValue();

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenuTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenuTest.java
@@ -124,7 +124,6 @@ public class NewResourcesMenuTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testOnProjectContextChangedEnabled() {
-
         doAnswer( new Answer() {
             public Object answer( final InvocationOnMock invocation ) {
                 final Object[] args = invocation.getArguments();
@@ -135,8 +134,13 @@ public class NewResourcesMenuTest {
         } ).when( handler ).acceptContext( any( Callback.class ) );
 
         menu.onChange();
+        verify( handler,
+                times( 1 ) ).acceptContext( any( Callback.class ) );
 
         final List<MenuItem> menus = menu.getMenuItems();
+        verify( handler,
+                times( 2 ) ).acceptContext( any( Callback.class ) );
+
         final MenuItem mi = menus.get( 0 );
         assertTrue( mi.isEnabled() );
     }
@@ -144,7 +148,6 @@ public class NewResourcesMenuTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testOnProjectContextChangedDisabled() {
-
         doAnswer( new Answer() {
             public Object answer( final InvocationOnMock invocation ) {
                 final Object[] args = invocation.getArguments();
@@ -155,10 +158,33 @@ public class NewResourcesMenuTest {
         } ).when( handler ).acceptContext( any( Callback.class ) );
 
         menu.onChange();
+        verify( handler,
+                times( 1 ) ).acceptContext( any( Callback.class ) );
 
         final List<MenuItem> menus = menu.getMenuItems();
+        verify( handler,
+                times( 2 ) ).acceptContext( any( Callback.class ) );
+
         final MenuItem mi = menus.get( 0 );
         assertFalse( mi.isEnabled() );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getMenuItemsSynchronizesEnabledState() {
+        menu.getMenuItems();
+
+        verify( handler,
+                times( 1 ) ).acceptContext( any( Callback.class ) );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getMenuItemsWithoutProjectSynchronizesEnabledState() {
+        menu.getMenuItemsWithoutProject();
+
+        verify( handler,
+                times( 1 ) ).acceptContext( any( Callback.class ) );
     }
 
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-349

This PR ensures the ```MenuItems``` enabled/disabled state is initialised correctly when the Menu's items are requested (by, for example, navigating to the Authoring Perspective).