### PR TITLE
[6.5.x] RHBRMS-349: New Item Menu: No Project selected, all items enabled after Perspective reset (#437)

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenu.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenu.java
@@ -23,53 +23,29 @@ import javax.inject.Inject;
 
 import org.guvnor.common.services.project.context.ProjectContext;
 import org.guvnor.common.services.project.context.ProjectContextChangeEvent;
-import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.ErrorCallback;
-import org.jboss.errai.common.client.api.RemoteCallback;
-import org.kie.workbench.common.screens.projecteditor.client.validation.ProjectNameValidator;
 import org.kie.workbench.common.services.shared.project.KieProject;
-import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.kie.workbench.common.widgets.client.resources.i18n.ToolsMenuConstants;
-import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.PlaceManager;
-import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
-import org.uberfire.ext.editor.commons.client.file.CopyPopup;
-import org.uberfire.ext.editor.commons.client.file.CopyPopupView;
-import org.uberfire.ext.editor.commons.client.file.DeletePopup;
-import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
-import org.uberfire.ext.editor.commons.client.file.RenamePopup;
-import org.uberfire.ext.editor.commons.client.file.RenamePopupView;
-import org.uberfire.ext.editor.commons.service.CopyService;
-import org.uberfire.ext.editor.commons.service.DeleteService;
-import org.uberfire.ext.editor.commons.service.RenameService;
 import org.uberfire.mvp.Command;
-import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 
 @ApplicationScoped
 public class ProjectMenu {
 
-    @Inject
     private PlaceManager placeManager;
+    private ProjectContext context;
+
+    public ProjectMenu() {
+        //Zero argument constructor for CDI proxies
+    }
 
     @Inject
-    protected Caller<KieProjectService> projectService;
-
-    @Inject
-    protected Caller<RenameService> renameService;
-
-    @Inject
-    protected Caller<DeleteService> deleteService;
-
-    @Inject
-    protected Caller<CopyService> copyService;
-
-    @Inject
-    protected ProjectContext context;
-
-    @Inject
-    protected ProjectNameValidator projectNameValidator;
+    public ProjectMenu( final PlaceManager placeManager,
+                        final ProjectContext context ) {
+        this.placeManager = placeManager;
+        this.context = context;
+    }
 
     private MenuItem projectScreen = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.ProjectEditor() ).respondsWith(
             new Command() {
@@ -87,102 +63,13 @@ public class ProjectMenu {
                 }
             } ).endMenu().build().getItems().get( 0 );
 
-    private MenuItem copyProject = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.CopyProject() ).respondsWith(
-            new Command() {
-                @Override
-                public void execute() {
-                    final Path path = context.getActiveProject().getRootPath();
-                    final CopyPopupView copyPopupView = CopyPopup.getDefaultView();
-                    new CopyPopup( path,
-                                   projectNameValidator,
-                                   new CommandWithFileNameAndCommitMessage() {
-                                       @Override
-                                       public void execute( FileNameAndCommitMessage payload ) {
-                                           copyService.call( new RemoteCallback<Void>() {
-
-                                               @Override
-                                               public void callback( final Void o ) {
-                                                   copyPopupView.hide();
-                                               }
-                                           }, new ErrorCallback<Void>() {
-
-                                               @Override
-                                               public boolean error( final Void o,
-                                                                     final Throwable throwable ) {
-                                                   copyPopupView.hide();
-                                                   return false;
-                                               }
-                                           } ).copy( path,
-                                                     payload.getNewFileName(),
-                                                     payload.getCommitMessage() );
-                                       }
-                                   },
-                                   copyPopupView ).show();
-                }
-            } ).endMenu().build().getItems().get( 0 );
-
-    private MenuItem renameProject = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.RenameProject() ).respondsWith(
-            new Command() {
-                @Override
-                public void execute() {
-                    final Path path = context.getActiveProject().getRootPath();
-                    final RenamePopupView renamePopupView = RenamePopup.getDefaultView();
-                    new RenamePopup( path,
-                                     projectNameValidator,
-                                     new CommandWithFileNameAndCommitMessage() {
-                                         @Override
-                                         public void execute( FileNameAndCommitMessage payload ) {
-                                             renameService.call( new RemoteCallback<Void>() {
-
-                                                 @Override
-                                                 public void callback( final Void o ) {
-                                                     renamePopupView.hide();
-                                                 }
-                                             }, new ErrorCallback<Void>() {
-
-                                                 @Override
-                                                 public boolean error( final Void o,
-                                                                       final Throwable throwable ) {
-                                                     renamePopupView.hide();
-                                                     return false;
-                                                 }
-                                             } ).rename( path,
-                                                         payload.getNewFileName(),
-                                                         payload.getCommitMessage() );
-                                         }
-                                     },
-                                     renamePopupView ).show();
-
-                }
-            } ).endMenu().build().getItems().get( 0 );
-
-    private MenuItem removeProject = MenuFactory.newSimpleItem( ToolsMenuConstants.INSTANCE.RemoveProject() ).respondsWith(
-            new Command() {
-                @Override
-                public void execute() {
-
-                    new DeletePopup( new ParameterizedCommand<String>() {
-                        @Override
-                        public void execute( String payload ) {
-                            deleteService.call().delete(
-                                    context.getActiveProject().getRootPath(),
-                                    payload );
-                        }
-                    } ).show();
-
-                }
-            } ).endMenu().build().getItems().get( 0 );
-
     public List<MenuItem> getMenuItems() {
+        enableToolsMenuItems( (KieProject) context.getActiveProject() );
+
         ArrayList<MenuItem> menuItems = new ArrayList<MenuItem>();
 
         menuItems.add( projectScreen );
-
         menuItems.add( projectStructureScreen );
-
-//        menuItems.add(removeProject);
-//        menuItems.add(renameProject);
-//        menuItems.add(copyProject);
 
         return menuItems;
     }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenuTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/menu/ProjectMenuTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.menu;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.common.services.project.context.ProjectContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.project.KieProject;
+import org.mockito.Mock;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.workbench.model.menu.MenuItem;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ProjectMenuTest {
+
+    private ProjectMenu menu;
+
+    @Mock
+    private PlaceManager placeManager;
+
+    @Mock
+    private ProjectContext projectContext;
+
+    @Before
+    public void setup() {
+        menu = new ProjectMenu( placeManager,
+                                projectContext );
+    }
+
+    @Test
+    public void getMenuItemsSynchronizesDisabledState() {
+        final List<MenuItem> menus = menu.getMenuItems();
+
+        assertFalse( menus.get( 0 ).isEnabled() );
+        assertTrue( menus.get( 1 ).isEnabled() );
+    }
+
+    @Test
+    public void getMenuItemsSynchronizesEnabledState() {
+        when( projectContext.getActiveProject() ).thenReturn( mock( KieProject.class ) );
+
+        final List<MenuItem> menus = menu.getMenuItems();
+
+        assertTrue( menus.get( 0 ).isEnabled() );
+        assertTrue( menus.get( 1 ).isEnabled() );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenuTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/handlers/NewResourcesMenuTest.java
@@ -59,6 +59,9 @@ public class NewResourcesMenuTest {
     @Mock
     private Command command;
 
+    @Mock
+    private ProjectContext projectContext;
+
     @Before
     public void setup() {
         when( iocBeanManager.lookupBeans( NewResourceHandler.class ) ).thenReturn( new ArrayList<IOCBeanDef<NewResourceHandler>>() {{
@@ -70,7 +73,8 @@ public class NewResourcesMenuTest {
         when( handler.getCommand( newResourcePresenter ) ).thenReturn( command );
 
         menu = new NewResourcesMenu( iocBeanManager,
-                                     newResourcePresenter );
+                                     newResourcePresenter,
+                                     projectContext );
 
         menu.setup();
     }
@@ -129,8 +133,15 @@ public class NewResourcesMenuTest {
                                            any( Callback.class ) );
 
         menu.onProjectContextChanged( event );
+        verify( handler,
+                times( 1 ) ).acceptContext( any( ProjectContext.class ),
+                                            any( Callback.class ) );
 
         final List<MenuItem> menus = menu.getMenuItems();
+        verify( handler,
+                times( 2 ) ).acceptContext( any( ProjectContext.class ),
+                                            any( Callback.class ) );
+
         final MenuItem mi = menus.get( 0 );
         assertTrue( mi.isEnabled() );
     }
@@ -151,10 +162,37 @@ public class NewResourcesMenuTest {
                                            any( Callback.class ) );
 
         menu.onProjectContextChanged( event );
+        verify( handler,
+                times( 1 ) ).acceptContext( any( ProjectContext.class ),
+                                            any( Callback.class ) );
 
         final List<MenuItem> menus = menu.getMenuItems();
+        verify( handler,
+                times( 2 ) ).acceptContext( any( ProjectContext.class ),
+                                            any( Callback.class ) );
+
         final MenuItem mi = menus.get( 0 );
         assertFalse( mi.isEnabled() );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getMenuItemsSynchronizesEnabledState() {
+        menu.getMenuItems();
+
+        verify( handler,
+                times( 1 ) ).acceptContext( any( ProjectContext.class ),
+                                            any( Callback.class ) );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getMenuItemsWithoutProjectSynchronizesEnabledState() {
+        menu.getMenuItemsWithoutProject();
+
+        verify( handler,
+                times( 1 ) ).acceptContext( any( ProjectContext.class ),
+                                            any( Callback.class ) );
     }
 
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-349

    (cherry picked from commit 903d0068908a59bb09ced6da9d2aa0a1165656cc)

This is the corollary of https://github.com/droolsjbpm/kie-wb-common/pull/437 for 6.5.x.