### PR TITLE
[GSS] project created by another user is displayed when multiple users create it concurrently

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/pom.xml
@@ -122,6 +122,25 @@
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-services-backend</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/main/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -77,7 +78,7 @@ import static java.util.Collections.*;
 import static org.uberfire.commons.validation.PortablePreconditions.*;
 
 @Service
-@ApplicationScoped
+@Dependent
 public class ExplorerServiceImpl
         implements ExplorerService {
 

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImplTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImplTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.screens.explorer.backend.server;
+
+import org.jboss.weld.environment.se.Weld;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.screens.explorer.service.ExplorerService;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+import static org.junit.Assert.assertNotSame;
+
+
+public class ExplorerServiceImplTest {
+
+    protected Weld weld;
+    protected BeanManager beanManager;
+    private Bean explorerServiceBean;
+    private CreationalContext explorerServiceBeanContext;
+
+    @Before
+    public void setUp() throws Exception {
+        weld = new Weld();
+        beanManager = weld.initialize().getBeanManager();
+
+        explorerServiceBean = ( Bean ) beanManager.getBeans( ExplorerService.class ).iterator().next();
+        explorerServiceBeanContext = beanManager.createCreationalContext( explorerServiceBean );
+
+    }
+
+    @Test
+    public void explorerServiceShouldBeADependentBean() {
+        ExplorerService reference1 = lookupReference();
+        ExplorerService reference2 = lookupReference();
+        assertNotSame( reference1, reference2 );
+    }
+
+    private ExplorerService lookupReference() {
+        return ( ExplorerService ) beanManager.getReference( explorerServiceBean,
+                                                             ExplorerService.class,
+                                                             explorerServiceBeanContext );
+    }
+
+    @After
+    public void tearDown() {
+        if ( weld != null && beanManager != null ) {
+            weld.shutdown();
+        }
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImplTestUtil.java
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/java/org/kie/workbench/common/screens/explorer/backend/server/ExplorerServiceImplTestUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.workbench.common.screens.explorer.backend.server;
+
+import org.guvnor.m2repo.service.M2RepoService;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import static org.mockito.Mockito.mock;
+
+@Singleton
+@Alternative
+public class ExplorerServiceImplTestUtil {
+
+    @Produces
+    @Alternative
+    public KieProjectService kieProjectService() {
+        return mock( KieProjectService.class );
+    }
+
+
+    @Produces
+    @Alternative
+    public M2RepoService m2RepoService() {
+        return mock( M2RepoService.class );
+    }
+
+}

--- a/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/resources/META-INF/beans.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-explorer/kie-wb-common-project-explorer-backend/src/test/resources/META-INF/beans.xml
@@ -1,15 +1,7 @@
-<!--
-  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+<beans>
+  <alternatives>
+    <class>org.guvnor.test.GuvnorTestAppSetup</class>
+    <class>org.guvnor.test.TestIdentityFactory</class>
+    <class>org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImplTestUtil</class>
+  </alternatives>
+</beans>


### PR DESCRIPTION
**Steps do reproduce the issue:**

1. Login User A on Host A (Chrome)
2. Login User B on  Host B (Safari)
3. Select a Project X on User B
4. Create a Project Y on User A (with != group)
5.  Folder from Project X (User B) is displayed instead of Folder of Project Y.

**Why?**
The issue begins here:
````
    public void onProjectAdded( @Observes final NewProjectEvent event ) {
        if ( view.isVisible() && event.getProject() != null ) {

            if ( sessionInfo.getId().equals( event.getSessionId() )
                    && isInActiveBranch( event.getProject() ) ) {

                refresh( event.getProject() );

            } else {

                refresh();

            }
        }
    }
````
When a project is added in Host A, Host A calls refresh( event.getProject() ); and Host B calls refresh().
Both calls are handled by ExplorerServiceImpl (ApplicationScoped) getContent(ProjectExplorerContentQuery query).
ProjectExplorer has a ProjectContentResolver, that has a ExplorerServiceHelper, that has a FolderListingResolver. 
FolderListingResolver is not a thread-safe class, and his stated is mutable via: 
````
private void init( final FolderItem selectedItem,
                       final Project selectedProject,
                       final Package selectedPackage,
                       final ExplorerServiceHelper helper ) {
        this.selectedItem = selectedItem;
        this.selectedProject = selectedProject;
        this.selectedPackage = selectedPackage;
        this.helper = helper;
    }
````
Sometimes the folder listing get mixed when multiple threads are handled by ExplorerServiceImpl:
`````
ee98c5d3a086d36bef5df18c92da9eac1af968e5c7ef978f65ee73877c14df User A session - task-3

[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-3)  Source: refresh projectpath before Session: ee98c5d3a086d36bef5df18c92da9eac1af968e5c7ef978f65ee73877c14df log default://master@uf-playground/dorinha3


a0bd7a28530d74462c9addf4c9bbd13f6c46accd0596ac4eae77d9a64091a1 User B session - task-2 (has z folder)
[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-2)  Source: refresh emptypath before Session: a0bd7a28530d74462c9addf4c9bbd13f6c46accd0596ac4eae77d9a64091a1 log default://master@uf-playground/z
[org.kie.workbench.common.screens.explorer.backend.server.Content] (default task-2) folder .z
[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-2)  Source: refresh emptypath before Session: a0bd7a28530d74462c9addf4c9bbd13f6c46accd0596ac4eae77d9a64091a1 log path after query default://master@uf-playground/z
[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-2)  Source: refresh emptypath before Session: a0bd7a28530d74462c9addf4c9bbd13f6c46accd0596ac4eae77d9a64091a1 log path after resolve default://master@uf-playground/z
[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-2) .z
[org.kie.workbench.common.screens.explorer.backend.server.Content] (default task-3) folder .z

ee98c5d3a086d36bef5df18c92da9eac1af968e5c7ef978f65ee73877c14df User A session - task-3 -> Right project, repo but wrong folder
[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-3)  Source: refresh projectpath before Session: ee98c5d3a086d36bef5df18c92da9eac1af968e5c7ef978f65ee73877c14df log path after query default://master@uf-playground/dorinha3
[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-3)  Source: refresh projectpath before Session: ee98c5d3a086d36bef5df18c92da9eac1af968e5c7ef978f65ee73877c14df log path after resolve default://master@uf-playground/dorinha3
[org.kie.workbench.common.screens.explorer.backend.server.ExplorerServiceImpl] (default task-3) folder.z
 `````
 
**Fix:**
We have two directions to go, or make folder listing thread safe or make ExplorerServiceImpl a Dependent.

I took the Dependent approach because I'm not sure that is not other cases in explorer services that suffers from the same shared state issues.