### PR TITLE
PLANNER-536 Workbench solver editor: bendable score combobox selection should allow filling in hard and soft level size

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/main/java/org/kie/workbench/common/screens/datamodeller/events/DataModelerEvent.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/main/java/org/kie/workbench/common/screens/datamodeller/events/DataModelerEvent.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.screens.datamodeller.events;
 import org.guvnor.common.services.project.model.Project;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
 import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 import org.uberfire.backend.vfs.Path;
 
@@ -28,6 +29,8 @@ public class DataModelerEvent {
     protected DataObject currentDataObject;
 
     protected ObjectProperty currentField;
+
+    protected Method currentMethod;
 
     protected Project currentProject;
 
@@ -102,13 +105,26 @@ public class DataModelerEvent {
         this.currentField = currentField;
     }
 
-    public Project getCurrentProject() {
-        return currentProject;
-    }
-
     public DataModelerEvent withCurrentProject( Project currentProject ) {
         setCurrentProject( currentProject );
         return this;
+    }
+
+    public void setCurrentMethod( Method currentMethod ) {
+        this.currentMethod = currentMethod;
+    }
+
+    public Method getCurrentMethod() {
+        return currentMethod;
+    }
+
+    public DataModelerEvent withCurrentMethod( Method currentMethod ) {
+        setCurrentMethod( currentMethod );
+        return this;
+    }
+
+    public Project getCurrentProject() {
+        return currentProject;
     }
 
     public void setCurrentProject( Project currentProject ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/main/java/org/kie/workbench/common/screens/datamodeller/events/DataObjectRenamedEvent.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/main/java/org/kie/workbench/common/screens/datamodeller/events/DataObjectRenamedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,27 +16,14 @@
 
 package org.kie.workbench.common.screens.datamodeller.events;
 
+import org.guvnor.common.services.project.model.Project;
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
 
 @Portable
-public enum ChangeType {
+public class DataObjectRenamedEvent extends DataModelerEvent {
 
-    DATA_MODEL_STATUS_CHANGE,
-    OBJECT_NAME_CHANGE,
-    CLASS_NAME_CHANGE,
-    SUPER_CLASS_NAME_CHANGE,
-    PACKAGE_NAME_CHANGE,
-    FIELD_NAME_CHANGE,
-    FIELD_TYPE_CHANGE,
-    FIELD_ANNOTATION_VALUE_CHANGE,
-    FIELD_ANNOTATION_ADD_CHANGE,
-    FIELD_ANNOTATION_REMOVE_CHANGE,
-    TYPE_ANNOTATION_VALUE_CHANGE,
-    TYPE_ANNOTATION_ADD_CHANGE,
-    TYPE_ANNOTATION_REMOVE_CHANGE,
-    METHOD_ADD_CHANGE,
-    METHOD_REMOVE_CHANGE,
-    METHOD_ANNOTATION_ADD_CHANGE,
-    NESTED_CLASS_ADD_CHANGE,
-    NESTED_CLASS_REMOVE_CHANGE;
+    public DataObjectRenamedEvent() {
+    }
+
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/main/java/org/kie/workbench/common/screens/datamodeller/service/DataModelerService.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/main/java/org/kie/workbench/common/screens/datamodeller/service/DataModelerService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.bus.server.annotations.Remote;
+import org.kie.workbench.common.screens.datamodeller.model.DataModelerError;
 import org.kie.workbench.common.screens.datamodeller.model.EditorModelContent;
 import org.kie.workbench.common.screens.datamodeller.model.GenerationResult;
 import org.kie.workbench.common.screens.datamodeller.model.TypeInfoResult;
@@ -38,6 +39,7 @@ import org.kie.workbench.common.services.datamodeller.driver.model.AnnotationSou
 import org.kie.workbench.common.services.datamodeller.driver.model.AnnotationSourceResponse;
 import org.kie.workbench.common.services.shared.project.KieProject;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.data.Pair;
 
 @Remote
 public interface DataModelerService {
@@ -75,13 +77,15 @@ public interface DataModelerService {
             final boolean saveCurrentChanges, final String source, final DataObject dataObject,
             final Metadata metadata );
 
-    void delete( final Path path, final DataObject dataObject, final String comment );
+    void delete( final Path path, final String comment );
 
     GenerationResult refactorClass( final Path path, final String newPackageName, final String newClassName );
 
     List<ValidationMessage> validate( String source, final Path path, DataObject dataObject );
 
     TypeInfoResult loadJavaTypeInfo( final String source);
+
+    GenerationResult loadDataObject( final Path projectPath, final String source, final Path sourcePath );
 
     List<PropertyType> getBasePropertyTypes();
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/test/java/org/kie/workbench/common/screens/datamodeller/events/DataModelerEventTest.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/src/test/java/org/kie/workbench/common/screens/datamodeller/events/DataModelerEventTest.java
@@ -19,8 +19,10 @@ package org.kie.workbench.common.screens.datamodeller.events;
 import org.guvnor.common.services.project.model.Project;
 import org.junit.Test;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
 import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.MethodImpl;
 import org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
@@ -33,6 +35,7 @@ public class DataModelerEventTest {
     public void createEvent() {
         DataObject currentDataObject = new DataObjectImpl();
         ObjectProperty currentField = new ObjectPropertyImpl();
+        Method currentMethod = new MethodImpl();
         Project currentProject = new Project();
         String source = "testSource";
         String contextId = "testContextId";
@@ -42,6 +45,7 @@ public class DataModelerEventTest {
         DataModelerEvent event = new DataModelerEvent()
                 .withCurrentDataObject( currentDataObject )
                 .withCurrentField( currentField )
+                .withCurrentMethod( currentMethod )
                 .withCurrentProject( currentProject )
                 .withSource( source )
                 .withContextId( contextId )
@@ -49,6 +53,7 @@ public class DataModelerEventTest {
 
         assertEquals( currentDataObject, event.getCurrentDataObject() );
         assertEquals( currentField, event.getCurrentField() );
+        assertEquals( currentMethod, event.getCurrentMethod() );
         assertEquals( currentProject, event.getCurrentProject() );
         assertEquals( source, event.getSource() );
         assertEquals( contextId, event.getContextId() );

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/handler/JPADomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/src/main/java/org/kie/workbench/common/screens/datamodeller/backend/server/handler/JPADomainHandler.java
@@ -30,7 +30,6 @@ import org.hibernate.envers.Audited;
 import org.hibernate.envers.RelationTargetAuditMode;
 import org.kie.workbench.common.services.datamodeller.core.Annotation;
 import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
-import org.kie.workbench.common.services.datamodeller.core.DataModel;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
 import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
@@ -90,11 +89,6 @@ public class JPADomainHandler implements DomainHandler {
                 }
             }
         }
-    }
-
-    @Override
-    public void processDataObject( DataObject dataObject, DataModel dataModel ) {
-        // No data object processing for this domain.
     }
 
     @Override

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenter.java
@@ -350,7 +350,6 @@ public class DataModelerScreenPresenter
             public void execute( final String comment ) {
                 view.showBusyIndicator( org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants.INSTANCE.Deleting() );
                 modelerService.call( getDeleteSuccessCallback(), new DataModelerErrorCallback( Constants.INSTANCE.modelEditor_deleting_error() ) ).delete( path,
-                                                                                                                                                           context.getDataObject(),
                                                                                                                                                            comment );
             }
         } );

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/AbstractDataModelCommand.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/AbstractDataModelCommand.java
@@ -171,7 +171,6 @@ public abstract class AbstractDataModelCommand implements DataModelCommand {
         if ( notifier != null ) {
             notifier.notifyObjectChange( changeType, context, source, dataObject, annotationClassName, memberName, oldValue, newValue );
         }
-
     }
 
     protected void notifyChange( DataModelerEvent event ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/AddMethodCommand.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/AddMethodCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.datamodeller.client.command;
+
+import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
+import org.kie.workbench.common.screens.datamodeller.events.ChangeType;
+import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectChangeEvent;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+public class AddMethodCommand extends AbstractDataModelCommand {
+
+    private final Method method;
+
+    public AddMethodCommand( final DataModelerContext context, final String source,
+                             final DataObject dataObject, final Method method,
+                             final DataModelChangeNotifier notifier ) {
+        super( context, source, dataObject, notifier );
+        this.method = PortablePreconditions.checkNotNull( "method", method );
+    }
+
+    @Override
+    public void execute() {
+        if ( method != null ) {
+            dataObject.addMethod( method );
+
+            DataModelerEvent event = new DataObjectChangeEvent()
+                    .withChangeType( ChangeType.METHOD_ADD_CHANGE )
+                    .withOldValue( null )
+                    .withNewValue( method )
+                    .withContextId( getContext().getContextId() )
+                    .withSource( getSource() )
+                    .withCurrentDataObject( getDataObject() )
+                    .withCurrentMethod( method );
+
+            notifyChange( event );
+        }
+
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/DataModelCommandBuilder.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/DataModelCommandBuilder.java
@@ -24,6 +24,7 @@ import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
 import org.kie.workbench.common.services.datamodeller.core.Annotation;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
 import org.kie.workbench.common.services.datamodeller.core.JavaClass;
+import org.kie.workbench.common.services.datamodeller.core.Method;
 import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
 
 @ApplicationScoped
@@ -85,6 +86,29 @@ public class DataModelCommandBuilder {
             final boolean doAdd ) {
         return new FieldAddOrRemoveAnnotationCommand( context, source, dataObject, field, annotationClassName, doAdd, notifier );
 
+    }
+
+    public AddMethodCommand buildMethodAddCommand( final DataModelerContext context, final String source,
+                                                                       final DataObject dataObject,
+                                                                       final Method method) {
+
+        return new AddMethodCommand( context, source, dataObject, method, notifier );
+    }
+
+    public RemoveMethodCommand buildMethodRemoveCommand( final DataModelerContext context, final String source,
+                                                   final DataObject dataObject,
+                                                   final Method method) {
+
+        return new RemoveMethodCommand( context, source, dataObject, method, notifier );
+    }
+
+    public MethodAddAnnotationCommand buildMethodAnnotationAddCommand( final DataModelerContext context, final String source,
+                                                                      final DataObject dataObject,
+                                                                      final Method method,
+                                                                      final String annotationClassName, final List<ValuePair> valuePairs ) {
+
+        return new MethodAddAnnotationCommand( context, source, dataObject, method,
+                annotationClassName, valuePairs, notifier );
     }
 
     public DataObjectAddAnnotationCommand buildDataObjectAddAnnotationCommand( final DataModelerContext context, final String source,

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/FieldTypeChangeCommand.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/FieldTypeChangeCommand.java
@@ -26,26 +26,15 @@ public class FieldTypeChangeCommand extends AbstractDataModelCommand {
 
     protected ObjectProperty field;
 
-    protected String newType;
-
     protected boolean multiple;
 
     public FieldTypeChangeCommand( DataModelerContext context, String source, DataObject dataObject,
             ObjectProperty field, String newType, boolean multiple, DataModelChangeNotifier notifier ) {
 
-        super( context, source, dataObject, null, null, null, false, notifier );
+        super( context, source, dataObject, null, null, newType, false, notifier );
         this.field = field;
-        this.newType = newType;
         this.multiple = multiple;
 
-    }
-
-    public String getNewType() {
-        return newType;
-    }
-
-    public void setNewType( String newType ) {
-        this.newType = newType;
     }
 
     public boolean isMultiple() {
@@ -69,6 +58,8 @@ public class FieldTypeChangeCommand extends AbstractDataModelCommand {
 
         String oldType = field.getClassName();
 
+        String newType = (String) newValue;
+
         field.setClassName( newType );
         field.setMultiple( multiple );
         if ( multiple && field.getBag() == null ) {
@@ -86,7 +77,7 @@ public class FieldTypeChangeCommand extends AbstractDataModelCommand {
         }
 
         notifyFieldChange( ChangeType.FIELD_TYPE_CHANGE, context, source, dataObject, field, null, null, oldType,
-                newValue );
+                newType );
 
     }
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/MethodAddAnnotationCommand.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/MethodAddAnnotationCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.datamodeller.client.command;
+
+import java.util.List;
+
+import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
+import org.kie.workbench.common.screens.datamodeller.events.ChangeType;
+import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectChangeEvent;
+import org.kie.workbench.common.services.datamodeller.core.Annotation;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
+
+public class MethodAddAnnotationCommand extends AbstractDataModelCommand {
+
+    private final Method method;
+
+    private Annotation annotation;
+
+    public MethodAddAnnotationCommand( final DataModelerContext context, final String source,
+                                       final DataObject dataObject, final Method method, final String annotationClassName,
+                                       final List<ValuePair> valuePairs, final DataModelChangeNotifier notifier ) {
+        super( context, source, dataObject, notifier );
+        this.annotationClassName = annotationClassName;
+        this.method = method;
+        this.valuePairs = valuePairs;
+    }
+
+    @Override
+    public void execute() {
+        if ( annotation == null ) {
+            annotation = new AnnotationImpl( context.getAnnotationDefinition( annotationClassName ) );
+            if ( valuePairs != null ) {
+                for ( ValuePair valuePair : valuePairs ) {
+                    annotation.setValue( valuePair.getName(), valuePair.getValue() );
+                }
+            }
+        }
+
+        Annotation existingAnnotation = method.getAnnotation( annotation.getClassName() );
+
+        if ( existingAnnotation != null ) {
+            method.removeAnnotation( annotation.getClassName() );
+        }
+
+        method.addAnnotation( annotation );
+
+        DataModelerEvent event = new DataObjectChangeEvent()
+                .withChangeType( ChangeType.METHOD_ANNOTATION_ADD_CHANGE )
+                .withOldValue( null )
+                .withNewValue( this.annotation )
+                .withContextId( getContext().getContextId() )
+                .withSource( getSource() )
+                .withCurrentDataObject( getDataObject() )
+                .withCurrentMethod( method );
+
+        notifyChange( event );
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/RemoveMethodCommand.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/command/RemoveMethodCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.datamodeller.client.command;
+
+import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
+import org.kie.workbench.common.screens.datamodeller.events.ChangeType;
+import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
+import org.kie.workbench.common.screens.datamodeller.events.DataObjectChangeEvent;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+public class RemoveMethodCommand extends AbstractDataModelCommand {
+
+    private final Method method;
+
+    public RemoveMethodCommand( final DataModelerContext context, final String source,
+                                final DataObject dataObject, final Method method,
+                                final DataModelChangeNotifier notifier ) {
+        super( context, source, dataObject, notifier );
+        this.method = PortablePreconditions.checkNotNull( "method", method );
+    }
+
+    @Override
+    public void execute() {
+        if ( method != null ) {
+            dataObject.removeMethod( method );
+
+            DataModelerEvent event = new DataObjectChangeEvent()
+                    .withChangeType( ChangeType.METHOD_REMOVE_CHANGE)
+                    .withOldValue( method )
+                    .withNewValue( null )
+                    .withContextId( getContext().getContextId() )
+                    .withSource( getSource() )
+                    .withCurrentDataObject( getDataObject() )
+                    .withCurrentMethod( method );
+
+            notifyChange( event );
+        }
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/DomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/DomainHandler.java
@@ -31,6 +31,4 @@ public interface DomainHandler {
 
     void postCommandProcessing( DataModelCommand command );
 
-    void postEventProcessing( DataModelerEvent event );
-
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/advanceddomain/AdvancedDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/advanceddomain/AdvancedDomainHandler.java
@@ -51,8 +51,4 @@ public class AdvancedDomainHandler implements DomainHandler {
         //no post command processing for this domain.
     }
 
-    @Override
-    public void postEventProcessing( DataModelerEvent event ) {
-        //no post event processing for this domain.
-    }
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/droolsdomain/DroolsDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/droolsdomain/DroolsDomainHandler.java
@@ -21,8 +21,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerValueChangeEvent;
 
 @ApplicationScoped
 public class DroolsDomainHandler implements DomainHandler {
@@ -49,11 +47,6 @@ public class DroolsDomainHandler implements DomainHandler {
     @Override
     public void postCommandProcessing( DataModelCommand command ) {
         //no post command processing for this domain.
-    }
-
-    @Override
-    public void postEventProcessing( DataModelerEvent event ) {
-        //no post event processing for this domain.
     }
 
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/jpadomain/JPADomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/jpadomain/JPADomainHandler.java
@@ -28,8 +28,6 @@ import org.kie.workbench.common.screens.datamodeller.client.handlers.jpadomain.c
 import org.kie.workbench.common.screens.datamodeller.client.handlers.jpadomain.command.JPACommandBuilder;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.jpadomain.options.JPANewResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerValueChangeEvent;
 import org.kie.workbench.common.screens.datamodeller.model.jpadomain.JPADomainAnnotations;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
 import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
@@ -85,11 +83,6 @@ public class JPADomainHandler implements DomainHandler {
                     ( (AddPropertyCommand) command ).getProperty() );
             postCommand.execute();
         }
-    }
-
-    @Override
-    public void postEventProcessing( DataModelerEvent event ) {
-        //no post event processing for this domain.
     }
 
     public boolean isOptionEnabled( String option ) {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/maindomain/MainDomainHandler.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/handlers/maindomain/MainDomainHandler.java
@@ -21,8 +21,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.kie.workbench.common.screens.datamodeller.client.command.DataModelCommand;
 import org.kie.workbench.common.screens.datamodeller.client.handlers.DomainHandler;
 import org.kie.workbench.common.screens.datamodeller.client.widgets.common.domain.ResourceOptions;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerEvent;
-import org.kie.workbench.common.screens.datamodeller.events.DataModelerValueChangeEvent;
 
 @ApplicationScoped
 public class MainDomainHandler implements DomainHandler {
@@ -51,8 +49,4 @@ public class MainDomainHandler implements DomainHandler {
         //no post command processing for this domain.
     }
 
-    @Override
-    public void postEventProcessing( DataModelerEvent event ) {
-        //no post event processing for this domain.
-    }
 }

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowser.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/java/org/kie/workbench/common/screens/datamodeller/client/widgets/editor/DataObjectBrowser.java
@@ -402,13 +402,6 @@ public class DataObjectBrowser
         }
     }
 
-    private void executePostEventProcessing( DataModelerEvent event ) {
-        List<DomainHandler> handlers = handlerRegistry.getDomainHandlers();
-        for ( DomainHandler handler : handlers ) {
-            handler.postEventProcessing( event );
-        }
-    }
-
     public void redrawFields() {
         view.redrawTable();
     }
@@ -501,7 +494,6 @@ public class DataObjectBrowser
                 // For self references: in case name or package changes redraw properties table
                 dataProvider.refresh();
                 dataProvider.flush();
-                executePostEventProcessing( event );
             }
         }
     }
@@ -523,7 +515,6 @@ public class DataObjectBrowser
                     }
                 }
             }
-            executePostEventProcessing( event );
         }
     }
 
@@ -537,7 +528,6 @@ public class DataObjectBrowser
     private void notifyFieldDeleted( ObjectProperty deletedProperty ) {
         DataObjectFieldDeletedEvent dataObjectFieldDeletedEvent = new DataObjectFieldDeletedEvent( getContext().getContextId(), DataModelerEvent.DATA_OBJECT_BROWSER, getDataObject(), deletedProperty );
         dataModelerEvent.fire( dataObjectFieldDeletedEvent );
-        executePostEventProcessing( dataObjectFieldDeletedEvent );
     }
 
     private void notifyObjectSelected() {

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/resources/org/kie/workbench/common/screens/datamodeller/KieWorkbenchDatamodellerClient.gwt.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/main/resources/org/kie/workbench/common/screens/datamodeller/KieWorkbenchDatamodellerClient.gwt.xml
@@ -33,6 +33,7 @@
   <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>
   <inherits name="org.kie.workbench.common.widgets.metadata.KieWorkbenchMetadataWidget"/>
   <inherits name="org.kie.workbench.common.services.KieWorkbenchCommonServicesAPI"/>
+  <inherits name="org.kie.workbench.common.services.datamodeller.DataModellerCore" />
   <inherits name="org.kie.workbench.common.screens.datamodeller.KieWorkbenchDatamodellerAPI"/>
   <inherits name="org.kie.workbench.common.screens.javaeditor.KieWorkbenchCommonJavaEditorClient"/>
 

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/codegen/GenerationEngine.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/codegen/GenerationEngine.java
@@ -353,7 +353,7 @@ public class GenerationEngine {
     }
 
     /**
-     * Generate all annotations for a specific element (field or class)
+     * Generate all annotations for a specific element (field, class, or method)
      */
     public String generateAllAnnotationsString(GenerationContext generationContext, HasAnnotations hasAnnotations, String indent) throws Exception {
         VelocityContext vc = buildContext(generationContext);

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/HasMethods.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/HasMethods.java
@@ -22,7 +22,9 @@ public interface HasMethods {
 
     List<Method> getMethods();
 
-    Method addMethod(Method method);
+    Method addMethod( Method method );
 
-    Method removeMethod(Method method);
+    Method getMethod( String name, List<String> parameters );
+
+    Method removeMethod( Method method );
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/HasParameters.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/HasParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.datamodeller.backend.server.handler;
+package org.kie.workbench.common.services.datamodeller.core;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
-import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
-import org.kie.workbench.common.services.datamodeller.core.DataObject;
+public interface HasParameters {
 
-public interface DomainHandler {
+    List<Parameter> getParameters();
 
-    void setDefaultValues( DataObject dataObject, Map<String, Object> options );
-
-    List<AnnotationDefinition> getManagedAnnotations();
-
+    void setParameters(List<Parameter> parameters);
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/HasVisibility.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/HasVisibility.java
@@ -28,4 +28,6 @@ public interface HasVisibility {
 
     Visibility getVisibilty();
 
+    void setVisibility( Visibility visibility );
+
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/Parameter.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/Parameter.java
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.datamodeller.events;
+package org.kie.workbench.common.services.datamodeller.core;
 
-import org.jboss.errai.common.client.api.annotations.Portable;
-import org.kie.workbench.common.services.datamodeller.core.DataObject;
-import org.uberfire.backend.vfs.Path;
+public interface Parameter extends HasName {
 
-@Portable
-public class DataObjectSavedEvent extends DataModelerEvent {
+    Type getType();
+
+    void setType( Type type );
 
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/Type.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.datamodeller.backend.server.handler;
+package org.kie.workbench.common.services.datamodeller.core;
 
 import java.util.List;
-import java.util.Map;
 
-import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
-import org.kie.workbench.common.services.datamodeller.core.DataObject;
+public interface Type extends HasName {
 
-public interface DomainHandler {
+    List<Type> getTypeArguments();
 
-    void setDefaultValues( DataObject dataObject, Map<String, Object> options );
-
-    List<AnnotationDefinition> getManagedAnnotations();
-
+    void setTypeArguments( List<Type> typeArguments );
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/AbstractJavaType.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/AbstractJavaType.java
@@ -136,6 +136,11 @@ public abstract class AbstractJavaType extends AbstractHasAnnotations implements
         return visibility;
     }
 
+    @Override
+    public void setVisibility( Visibility visibility ) {
+        this.visibility = visibility;
+    }
+
     @Override public boolean equals( Object o ) {
         if ( this == o ) {
             return true;

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/JavaClassImpl.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/JavaClassImpl.java
@@ -19,10 +19,13 @@ package org.kie.workbench.common.services.datamodeller.core.impl;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.kie.workbench.common.services.datamodeller.core.JavaClass;
 import org.kie.workbench.common.services.datamodeller.core.JavaTypeKind;
 import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.Parameter;
+import org.kie.workbench.common.services.datamodeller.core.Type;
 import org.kie.workbench.common.services.datamodeller.core.Visibility;
 
 public class JavaClassImpl extends AbstractJavaType implements JavaClass {
@@ -108,17 +111,32 @@ public class JavaClassImpl extends AbstractJavaType implements JavaClass {
     }
 
     @Override
-    public Method addMethod(Method method) {
+    public Method addMethod( Method method ) {
         Iterator<Method> iterator = methods.listIterator();
         while ( iterator.hasNext() ) {
             Method existingMethod = iterator.next();
-            if (existingMethod.getName().equals( method.getName() )) {
+            if ( existingMethod.getName().equals( method.getName() ) && existingMethod.getParameters().equals( method.getParameters() ) ) {
                 iterator.remove();
                 break;
             }
         }
         methods.add( method );
+
         return method;
+    }
+
+    @Override
+    public Method getMethod( String name, List<String> parameterTypes ) {
+        for ( Method method : methods ) {
+            if ( method.getName().equals( name ) ) {
+                if ( method.getParameters() == null && parameterTypes == null ) {
+                    return method;
+                } else if ( method.getParameters().stream().map( p -> p.getType().getName() ).collect( Collectors.toList() ).equals( parameterTypes ) ) {
+                    return method;
+                }
+            }
+        }
+        return null;
     }
 
     @Override
@@ -175,8 +193,13 @@ public class JavaClassImpl extends AbstractJavaType implements JavaClass {
         if ( superClassName != null ? !superClassName.equals( javaClass.superClassName ) : javaClass.superClassName != null ) {
             return false;
         }
-        return !( interfaces != null ? !interfaces.equals( javaClass.interfaces ) : javaClass.interfaces != null );
-
+        if ( interfaces != null ? !interfaces.equals( javaClass.interfaces ) : javaClass.interfaces != null ) {
+            return false;
+        }
+        if ( nestedClasses != null ? !nestedClasses.equals( javaClass.nestedClasses ) : javaClass.nestedClasses != null ) {
+            return false;
+        }
+        return !( methods != null ? !methods.equals( javaClass.methods) : javaClass.methods != null );
     }
 
     @Override public int hashCode() {
@@ -185,6 +208,10 @@ public class JavaClassImpl extends AbstractJavaType implements JavaClass {
         result = 31 * result + ( superClassName != null ? superClassName.hashCode() : 0 );
         result = ~~result;
         result = 31 * result + ( interfaces != null ? interfaces.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( nestedClasses != null ? nestedClasses.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( methods != null ? methods.hashCode() : 0 );
         result = ~~result;
         result = 31 * result + ( _static ? 1 : 0 );
         result = ~~result;

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/MethodImpl.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/MethodImpl.java
@@ -20,25 +20,31 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.Parameter;
+import org.kie.workbench.common.services.datamodeller.core.Type;
+import org.kie.workbench.common.services.datamodeller.core.Visibility;
 
-public class MethodImpl implements Method {
+public class MethodImpl extends AbstractHasAnnotations implements Method {
 
     private String name;
 
-    private List<String> parameters = new ArrayList<>( );
+    private List<Parameter> parameters = new ArrayList<>( );
 
     private String body;
 
-    private String returnType;
+    private Type returnType;
+
+    private Visibility visibility = Visibility.PACKAGE_PRIVATE;
 
     public MethodImpl() {
     }
 
-    public MethodImpl( String name, List<String> parameters, String body, String returnType ) {
+    public MethodImpl( String name, List<Parameter> parameters, String body, Type returnType, Visibility visibility ) {
         this.name = name;
         this.parameters = parameters;
         this.body = body;
         this.returnType = returnType;
+        this.visibility = visibility;
     }
 
     @Override
@@ -52,8 +58,13 @@ public class MethodImpl implements Method {
     }
 
     @Override
-    public List<String> getParameters() {
+    public List<Parameter> getParameters() {
         return parameters;
+    }
+
+    @Override
+    public void setParameters( List<Parameter> parameters ) {
+        this.parameters = parameters;
     }
 
     @Override
@@ -62,8 +73,94 @@ public class MethodImpl implements Method {
     }
 
     @Override
-    public String getReturnType() {
+    public void setBody( String body ) {
+        this.body = body;
+    }
+
+    @Override
+    public Type getReturnType() {
         return returnType;
+    }
+
+    @Override
+    public void setReturnType( Type returnType ) {
+        this.returnType = returnType;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+        if ( !super.equals( o ) ) {
+            return false;
+        }
+
+        MethodImpl method = ( MethodImpl ) o;
+
+        if ( name != null ? !name.equals( method.name ) : method.name != null ) {
+            return false;
+        }
+        if ( body != null ? !body.equals( method.body ) : method.body != null ) {
+            return false;
+        }
+        if ( parameters != null ? !parameters.equals( method.parameters ) : method.parameters != null ) {
+            return false;
+        }
+        if ( returnType != null ? !returnType.equals( method.returnType ) : method.returnType != null ) {
+            return false;
+        }
+        return visibility == method.visibility;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = ~~result;
+        result = 31 * result + ( name != null ? name.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( body != null ? body.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( parameters != null ? parameters.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( returnType != null ? returnType.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( visibility != null ? visibility.hashCode() : 0 );
+        result = ~~result;
+        return result;
+    }
+
+    @Override
+    public boolean isPackagePrivate() {
+        return visibility == Visibility.PACKAGE_PRIVATE;
+    }
+
+    @Override
+    public boolean isPublic() {
+        return visibility == Visibility.PUBLIC;
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return visibility == Visibility.PRIVATE;
+    }
+
+    @Override
+    public boolean isProtected() {
+        return visibility == Visibility.PROTECTED;
+    }
+
+    @Override
+    public Visibility getVisibilty() {
+        return visibility;
+    }
+
+    @Override
+    public void setVisibility( Visibility visibility ) {
+        this.visibility = visibility;
     }
 
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/ObjectPropertyImpl.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/ObjectPropertyImpl.java
@@ -175,6 +175,11 @@ public class ObjectPropertyImpl extends AbstractHasAnnotations implements Object
         return visibility;
     }
 
+    @Override
+    public void setVisibility( Visibility visibility ) {
+        this.visibility = visibility;
+    }
+
     @Override public void setBaseType( boolean baseType ) {
         //do nothing
     }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/ParameterImpl.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/ParameterImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.datamodeller.core.impl;
+
+import org.kie.workbench.common.services.datamodeller.core.Parameter;
+import org.kie.workbench.common.services.datamodeller.core.Type;
+
+public class ParameterImpl implements Parameter {
+
+    private Type type;
+
+    private String name;
+
+    public ParameterImpl() {
+    }
+
+    public ParameterImpl( Type type, String name ) {
+        this.type = type;
+        this.name = name;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+    @Override
+    public void setType( Type type ) {
+        this.type = type;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName( String name ) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        ParameterImpl parameter = ( ParameterImpl ) o;
+
+        if ( type != null ? !type.equals( parameter.type ) : parameter.type != null ) {
+            return false;
+        }
+        return name != null ? name.equals( parameter.name ) : parameter.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type != null ? type.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + ( name != null ? name.hashCode() : 0 );
+        result = ~~result;
+        return result;
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/TypeImpl.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/core/impl/TypeImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.datamodeller.core.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.workbench.common.services.datamodeller.core.Type;
+
+public class TypeImpl implements Type {
+
+    private String name;
+
+    private List<Type> typeArguments;
+
+    public TypeImpl() {
+    }
+
+    public TypeImpl( String name ) {
+        this.name = name;
+        this.typeArguments = new ArrayList<>( 0 );
+    }
+
+
+    public TypeImpl( String name, List<Type> typeArguments ) {
+        this.name = name;
+        this.typeArguments = typeArguments;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName( String name ) {
+        this.name = name;
+    }
+
+    @Override
+    public List<Type> getTypeArguments() {
+        return typeArguments;
+    }
+
+    @Override
+    public void setTypeArguments( List<Type> typeArguments ) {
+        this.typeArguments = typeArguments;
+    }
+
+    @Override
+    public boolean equals( Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        TypeImpl type = ( TypeImpl ) o;
+
+        if ( name != null ? !name.equals( type.name ) : type.name != null ) {
+            return false;
+        }
+        return typeArguments != null ? typeArguments.equals( type.typeArguments ) : type.typeArguments == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + ( typeArguments != null ? typeArguments.hashCode() : 0 );
+        result = ~~result;
+        return result;
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/FilterHolder.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/FilterHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.screens.datamodeller.backend.server.handler;
+package org.kie.workbench.common.services.datamodeller.driver;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Collection;
 
-import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
-import org.kie.workbench.common.services.datamodeller.core.DataObject;
+public interface FilterHolder {
 
-public interface DomainHandler {
+    Collection<SourceFilter> getSourceFilters();
 
-    void setDefaultValues( DataObject dataObject, Map<String, Object> options );
+    Collection<NestedClassFilter> getNestedClassFilters();
 
-    List<AnnotationDefinition> getManagedAnnotations();
+    Collection<MethodFilter> getMethodFilters();
 
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/MethodFilter.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/MethodFilter.java
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-package org.kie.workbench.common.services.datamodeller.core;
+package org.kie.workbench.common.services.datamodeller.driver;
 
-import java.util.List;
+import org.jboss.forge.roaster.model.Method;
 
-public interface Method extends HasAnnotations, HasName, HasParameters, HasVisibility {
+/**
+ * Used for defining methods to be loaded by the DataModelerService. Any CDI beans available at deployment time will be used,
+ * and a method is loaded if any single {@link MethodFilter} accepts it.
+ */
+@FunctionalInterface
+public interface MethodFilter {
 
-    List<Parameter> getParameters();
-
-    void setParameters( List<Parameter> parameters );
-
-    String getBody();
-
-    void setBody( String body );
-
-    Type getReturnType();
-
-    void setReturnType( Type returnType );
-
+    /**
+     * Check if the given method is accepted by this filter.
+     * @param method A Java method that could be loaded.
+     * @return True if this method should be accepted.
+     */
+    boolean accept( Method<?, ?> method );
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/NestedClassFilter.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/NestedClassFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.datamodeller.driver;
+
+import org.jboss.forge.roaster.model.JavaType;
+
+/**
+ * Used for defining nested classes to be loaded by the DataModelerService. Any CDI beans available at deployment time will be used,
+ * and a nested class is loaded if any single {@link NestedClassFilter} accepts it.
+ */
+@FunctionalInterface
+public interface NestedClassFilter {
+
+    /**
+     * Check if the given nested class is accepted by this filter.
+     * @param javaType A Java type (nested class) that could be loaded.
+     * @return True if this nested class should be accepted.
+     */
+    boolean accept( JavaType<?> javaType );
+}

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/impl/FilterHolderImpl.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/impl/FilterHolderImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.datamodeller.driver.impl;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.services.datamodeller.driver.FilterHolder;
+import org.kie.workbench.common.services.datamodeller.driver.MethodFilter;
+import org.kie.workbench.common.services.datamodeller.driver.NestedClassFilter;
+import org.kie.workbench.common.services.datamodeller.driver.SourceFilter;
+
+@ApplicationScoped
+public class FilterHolderImpl implements FilterHolder {
+
+    @Inject
+    @Any
+    private Instance<SourceFilter> sourceFiltersInstance;
+
+    @Inject
+    @Any
+    private Instance<NestedClassFilter> nestedClassFiltersInstance;
+
+    @Inject
+    @Any
+    private Instance<MethodFilter> methodFiltersInstance;
+
+    private Collection<SourceFilter> sourceFilters;
+
+    private Collection<NestedClassFilter> nestedClassFilters;
+
+    private Collection<MethodFilter> methodFilters;
+
+    @PostConstruct
+    private void init() {
+        sourceFilters = StreamSupport.stream( sourceFiltersInstance.spliterator(), false ).collect( Collectors.toList() );
+        nestedClassFilters = StreamSupport.stream( nestedClassFiltersInstance.spliterator(), false ).collect( Collectors.toList() );
+        methodFilters = StreamSupport.stream( methodFiltersInstance.spliterator(), false ).collect( Collectors.toList() );
+    }
+
+    @PreDestroy
+    private void tearDown() {
+        sourceFilters.forEach( filter -> sourceFiltersInstance.destroy( filter ) );
+        sourceFilters.clear();
+
+        nestedClassFilters.forEach( filter -> nestedClassFiltersInstance.destroy( filter ) );
+        nestedClassFilters.clear();
+
+        methodFilters.forEach( filter -> methodFiltersInstance.destroy( filter ) );
+        methodFilters.clear();
+    }
+
+    @Override
+    public Collection<SourceFilter> getSourceFilters() {
+        return sourceFilters;
+    }
+
+    @Override
+    public Collection<NestedClassFilter> getNestedClassFilters() {
+        return nestedClassFilters;
+    }
+
+    @Override
+    public Collection<MethodFilter> getMethodFilters() {
+        return methodFilters;
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/impl/annotations/CommonAnnotations.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/driver/impl/annotations/CommonAnnotations.java
@@ -66,7 +66,6 @@ public class CommonAnnotations {
         commonAnnotations.add( DriverUtils.buildAnnotationDefinition( Remotable.class ) );
 
         //JPA domain annotations
-
         commonAnnotations.add( DriverUtils.buildAnnotationDefinition( Entity.class ) );
         commonAnnotations.add( DriverUtils.buildAnnotationDefinition( Id.class ) );
         commonAnnotations.add( DriverUtils.buildAnnotationDefinition( GeneratedValue.class ) );

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/util/DriverUtils.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/java/org/kie/workbench/common/services/datamodeller/util/DriverUtils.java
@@ -240,6 +240,19 @@ public class DriverUtils {
         }
     }
 
+    public static org.jboss.forge.roaster.model.Visibility buildVisibility( Visibility visibility ) {
+        switch ( visibility ) {
+            case PUBLIC:
+                return org.jboss.forge.roaster.model.Visibility.PUBLIC;
+            case PROTECTED:
+                return org.jboss.forge.roaster.model.Visibility.PROTECTED;
+            case PRIVATE:
+                return org.jboss.forge.roaster.model.Visibility.PRIVATE;
+            default:
+                return org.jboss.forge.roaster.model.Visibility.PACKAGE_PRIVATE;
+        }
+    }
+
     public static AnnotationRetention buildRetention( RetentionPolicy retention ) {
         switch ( retention ) {
             case RUNTIME:

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/ErraiApp.properties
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/ErraiApp.properties
@@ -45,8 +45,10 @@ org.kie.workbench.common.services.datamodeller.core.impl.JavaTypeInfoImpl \
 org.kie.workbench.common.services.datamodeller.core.impl.ModelFactoryImpl \
 org.kie.workbench.common.services.datamodeller.core.impl.MethodImpl \
 org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl \
+org.kie.workbench.common.services.datamodeller.core.impl.ParameterImpl \
 org.kie.workbench.common.services.datamodeller.core.impl.PropertyTypeFactoryImpl \
 org.kie.workbench.common.services.datamodeller.core.impl.PropertyTypeImpl \
+org.kie.workbench.common.services.datamodeller.core.impl.TypeImpl \
 org.kie.workbench.common.services.datamodeller.util.NamingUtils \
 org.kie.workbench.common.services.datamodeller.driver.model.DriverResponse \
 org.kie.workbench.common.services.datamodeller.driver.model.DriverRequest \

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_class.vm
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_class.vm
@@ -2,6 +2,7 @@
 ## Template to generate a pojo.
 ##
 #set($attributes =  $nameTool.sortedProperties($context.currentDataObject))
+#set($methods =  $context.currentDataObject.getMethods())
 #set($nestedClasses =  $context.currentDataObject.getNestedClasses())
 #set($className =   $context.currentDataObject.name)
 #set($packageName = $context.currentDataObject.packageName)
@@ -44,6 +45,14 @@ $engine.generateConstructors($context, "java_constructors")
 #foreach( $attr in $attributes)
     $engine.generateSetterGetter($context, $attr, "java_setter_getter")
 #end
+
+##
+## Generate methods
+##
+#foreach( $method in $methods)
+    $engine.generateMethod($context, $method, "java_method")
+#end
+
 ## Generate equals and hasCode if needed
 #if ($nameTool.hasEquals($context.currentDataObject))
 $engine.generateEquals($context, "java_equals")

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_class2.vm
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_class2.vm
@@ -2,6 +2,7 @@
 ## Template to generate a pojo.
 ##
 #set($attributes =  $nameTool.sortedProperties($currentDataObject))
+#set($methods =  $currentDataObject.getMethods())
 #set($nestedClasses =  $currentDataObject.getNestedClasses())
 #set($className =   $currentDataObject.name)
 #set($packageName = $currentDataObject.packageName)
@@ -43,6 +44,14 @@ $engine.generateAllConstructorsString($context, $currentDataObject, "    ")
 ##
 #foreach( $attr in $attributes)
 $engine.generateFieldGetterSetterString($context, $attr, "    ")
+
+#end
+
+##
+## Generate methods
+##
+#foreach( $method in $methods)
+    $engine.generateMethodString($context, $method, "    ")
 
 #end
 

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_method.vm
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_method.vm
@@ -1,3 +1,6 @@
-public $attr.returnType $attr.getName()($nameTool.resolveMethodParameters($attr.getParameters())) {
+#if ($nameTool.hasMethodAnnotations($attr))
+    $engine.generateAllAnnotationsString($context, $attr)
+#end
+$nameTool.resolveVisibility($attr) $nameTool.buildMethodReturnTypeString($attr.returnType) $attr.getName()($nameTool.buildMethodParameterString($attr.getParameters())) {
     $attr.getBody()
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_nested_class.vm
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/main/resources/org/kie/workbench/common/services/datamodeller/codegen/java_nested_class.vm
@@ -3,6 +3,9 @@
 ##
 #set($methods =  $attr.getMethods())
 #set($className =   $attr.getClassName())
+#if ($nameTool.hasClassAnnotations($attr))
+    $engine.generateAllAnnotationsString($context, $attr)
+#end
 public static class $className $nameTool.resolveSuperClassType($attr) $nameTool.resolveImplementedInterfacesType($attr) {
 
     static final long serialVersionUID = 1L;

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/DataModelerAssert.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/DataModelerAssert.java
@@ -24,7 +24,10 @@ import org.kie.workbench.common.services.datamodeller.core.Annotation;
 import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
 import org.kie.workbench.common.services.datamodeller.core.AnnotationValuePairDefinition;
 import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
 import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.kie.workbench.common.services.datamodeller.core.Parameter;
+import org.kie.workbench.common.services.datamodeller.core.Type;
 
 import static org.junit.Assert.*;
 
@@ -38,6 +41,7 @@ public class DataModelerAssert {
             assertEquals( obj1.getName(), obj2.getName() );
             assertEqualsAnnotations( obj1.getAnnotations(), obj2.getAnnotations() );
             assertEqualsProperties( obj1.getProperties(), obj2.getProperties() );
+            assertEqualsMethods( obj1.getMethods(), obj2.getMethods() );
 
         } else {
             assertNull( obj2 );
@@ -185,6 +189,75 @@ public class DataModelerAssert {
 
     public static void assertClassName( String className, DataObject dataObject ) {
         assertEquals( className, dataObject.getClassName() );
+    }
+
+    public static void assertEqualsMethods( List<Method> methods1, List<Method> methods2 ) {
+        if ( methods1 != null ) {
+            assertNotNull( methods2 );
+            assertEquals( methods1.size(), methods2.size() );
+
+            Map<String, Method> methodMap = new HashMap<>();
+            for ( Method method : methods2 ) {
+                methodMap.put( method.getName(), method );
+            }
+
+            for ( Method method : methods1 ) {
+                assertEqualsMethod( method, methodMap.get( method.getName() ) );
+            }
+        } else {
+            assertNull( methods2 );
+        }
+    }
+
+    public static void assertEqualsMethod( Method method1, Method method2 ) {
+        if ( method1 != null ) {
+            assertNotNull( method2 );
+
+            assertEquals( method1.getName(), method2.getName() );
+            assertEquals( method1.getBody(), method2.getBody() );
+            assertEquals( method1.getReturnType().getName(), method2.getReturnType().getName() );
+            assertEqualsTypeArguments( method1.getReturnType().getTypeArguments(), method2.getReturnType().getTypeArguments() );
+            assertEqualsParameters( method1.getParameters(), method2.getParameters() );
+        } else {
+            assertNull( method2 );
+        }
+    }
+
+    private static void assertEqualsParameters( List<Parameter> parameters1, List<Parameter> parameters2 ) {
+        if ( parameters1 != null ) {
+            assertNotNull( parameters2 );
+            assertEquals( parameters1.size(), parameters2.size() );
+
+            for ( int i = 0; i < parameters1.size(); i++ ) {
+                Parameter parameter1 = parameters1.get( i );
+                Parameter parameter2 = parameters2.get( i );
+
+                assertEquals( parameter1.getName(), parameter2.getName() );
+                assertEquals( parameter1.getType().getName(), parameter2.getType().getName() );
+                assertEqualsTypeArguments( parameter1.getType().getTypeArguments(), parameter2.getType().getTypeArguments() );
+            }
+        } else {
+            assertNull( parameters2 );
+        }
+
+    }
+
+    private static void assertEqualsTypeArguments( List<Type> typeArguments1, List<Type> typeArguments2 ) {
+        if ( typeArguments1 != null ) {
+            assertNotNull( typeArguments2 );
+            assertEquals( typeArguments1.size(), typeArguments2.size() );
+
+            for ( int i = 0; i < typeArguments1.size(); i++ ) {
+                Type type1 = typeArguments1.get( i );
+                Type type2 = typeArguments2.get( i );
+
+                assertEquals( type1.getName(), type2.getName() );
+                assertEqualsTypeArguments( type1.getTypeArguments(), type2.getTypeArguments() );
+            }
+        } else {
+            assertNull( typeArguments2 );
+        }
+
     }
 
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/codegen/GenerationEngineTest.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/codegen/GenerationEngineTest.java
@@ -23,6 +23,8 @@ import org.kie.workbench.common.services.datamodeller.core.*;
 import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
 import org.kie.workbench.common.services.datamodeller.core.impl.MethodImpl;
 import org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.ParameterImpl;
+import org.kie.workbench.common.services.datamodeller.core.impl.TypeImpl;
 import org.kie.workbench.common.services.datamodeller.driver.impl.DataModelOracleModelDriver;
 import org.kie.workbench.common.services.refactoring.backend.server.impact.ResourceReferenceCollector;
 import org.slf4j.Logger;
@@ -31,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.text.NumberFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -346,16 +349,21 @@ public class GenerationEngineTest {
     public void testMethodStringGeneration() {
 
         DataModel dataModel = dataModelOracleDriver.createModel();
-        List<String> parameters = Arrays.asList( "com.test.Object1", "com.test.Object1" );
-        Method method = new MethodImpl( "test", parameters, "return o1;", "com.test.Object1" );
 
-        DataObject object = dataModel.addDataObject("com.test.Object1");
+        Parameter parameter1 = new ParameterImpl( new TypeImpl( "com.test.Object1" ), "o1" );
+        Parameter parameter2 = new ParameterImpl( new TypeImpl( "com.test.Object1" ), "o2" );
+
+        Type returnType = new TypeImpl( "com.test.Object1" );
+
+        Method method = new MethodImpl( "test", Arrays.asList( parameter1, parameter2 ), "return o1;", returnType, Visibility.PUBLIC );
+
+        DataObject object = dataModel.addDataObject( "com.test.Object1" );
         object.addMethod( method );
 
         GenerationContext generationContext = new GenerationContext( dataModel );
 
         try {
-            String result = engine.generateMethodString(generationContext, method);
+            String result = engine.generateMethodString( generationContext, method );
             assertEquals( results.getProperty( "testMethodStringGeneration" ), results.getProperty( "testMethodStringGeneration" ), result );
         } catch ( Exception e ) {
             e.printStackTrace();

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package4/MethodsUpdateTest.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package4/MethodsUpdateTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.datamodeller.driver.package4;
+
+import java.util.List;
+import javax.annotation.Generated;
+
+import org.kie.workbench.common.services.datamodeller.parser.test.TestAnnotation;
+import org.kie.workbench.common.services.datamodeller.parser.test.TestAnnotation1;
+
+public class MethodsUpdateTest
+{
+
+    public MethodsUpdateTest()
+    {
+    }
+
+    @Generated("foo.bar.Generator")
+    public List<String> getTestString( List<MethodsUpdateTest> methodUpdateTestList )
+    {
+        return Arrays.asList("testString");
+    }
+
+    @Generated("foo.bar.Generator")
+    @TestAnnotation1("annotationParameter")
+    public void noOpMethodWithTestAnnotation()
+    {
+    }
+
+    public void ignoredMethod() {
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package4/MethodsUpdateTestResult.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package4/MethodsUpdateTestResult.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.datamodeller.driver.package4;
+
+import javax.annotation.Generated;
+
+import java.lang.Integer;
+import java.util.Arrays;
+import java.util.List;
+import org.kie.workbench.common.services.datamodeller.parser.test.TestAnnotation;
+import org.kie.workbench.common.services.datamodeller.parser.test.TestAnnotation1;
+
+public class MethodsUpdateTestResult
+{
+
+    public MethodsUpdateTestResult()
+    {
+    }
+
+    @Generated("foo.bar.Generator")
+    public List<Integer> getTestString( List<List<MethodsUpdateTestResult>> methodUpdateTestResultList, int intParameter )
+    {
+        return Arrays.asList(1);
+    }
+
+    @Generated("foo.bar.Generator")
+    @TestAnnotation1("annotationParameterUpdated")
+    public Integer noOpMethodWithTestAnnotationUpdated()
+    {
+        return 1;
+    }
+
+    public void ignoredMethod() {
+    }
+
+}

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package5/NestedClassUpdateTest.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package5/NestedClassUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.kie.workbench.common.services.datamodeller.driver.package5;
 
-package org.kie.workbench.common.screens.datamodeller.backend.server.handler;
+import javax.annotation.Generated;
 
-import java.util.List;
-import java.util.Map;
+public class NestedClassUpdateTest
+{
 
-import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
-import org.kie.workbench.common.services.datamodeller.core.DataObject;
+    public NestedClassUpdateTest()
+    {
+    }
 
-public interface DomainHandler {
+    @Generated("foo.bar.Generator")
+    public static class NestedClass
+    {
 
-    void setDefaultValues( DataObject dataObject, Map<String, Object> options );
+        @Generated("foo.bar.Generator")
+        public void method()
+        {
+        }
 
-    List<AnnotationDefinition> getManagedAnnotations();
+        public void ignoredMethod()
+        {
+        }
+
+    }
+
+    public static class IgnoredNestedClass
+    {
+    }
 
 }

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package5/NestedClassUpdateTestResult.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/resources/org/kie/workbench/common/services/datamodeller/driver/package5/NestedClassUpdateTestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.kie.workbench.common.services.datamodeller.driver.package5;
 
-package org.kie.workbench.common.screens.datamodeller.backend.server.handler;
+import javax.annotation.Generated;
 
-import java.util.List;
-import java.util.Map;
+public class NestedClassUpdateTestResult
+{
 
-import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
-import org.kie.workbench.common.services.datamodeller.core.DataObject;
+    public NestedClassUpdateTestResult()
+    {
+    }
 
-public interface DomainHandler {
+    @Generated("foo.bar.Generator")
+    public static class UpdatedNestedClass
+    {
 
-    void setDefaultValues( DataObject dataObject, Map<String, Object> options );
+        @Generated("foo.bar.Generator")
+        public void updatedMethod()
+        {
+        }
 
-    List<AnnotationDefinition> getManagedAnnotations();
+        public void ignoredMethod()
+        {
+        }
+
+    }
+
+    public static class IgnoredNestedClass
+    {
+    }
 
 }


### PR DESCRIPTION
Depends on https://github.com/droolsjbpm/optaplanner/pull/220.

The PR introduces concept of custom methods. Apart from generated methods (getters/setters/equals etc.) we might need to define custom methods in a data object required by upstream project (optaplanner engine in this case). For this purpose `@CustomMethod` annotation was added (method-level), which tells `JavaRoasterModelDriver` to load the method when transforming source to the data object.

Other changes
- Add MethodFilter
- Rename SourceFilter to JavaTypeFilter
- Add CommandBuilder methods to allow clients to manipulate with methods in a data object
