### PR TITLE
[6.5.x] RHBRMS-2516 : When importing external projects, the dependency are not taken and at application server also

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoader.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoader.java
@@ -29,17 +29,21 @@ import org.jboss.errai.common.client.api.RemoteCallback;
 import org.kie.workbench.common.services.shared.dependencies.DependencyService;
 import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
 import org.kie.workbench.common.services.shared.dependencies.NormalEnhancedDependency;
+import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 
 @Dependent
 public class DependencyLoader {
 
     private final List<Dependency> updateQueue = new ArrayList<Dependency>();
 
+    private       DependencyLoaderView        view;
     private final Caller<DependencyService>   dependencyService;
     private       EnhancedDependenciesManager manager;
 
     @Inject
-    public DependencyLoader( final Caller<DependencyService> dependencyService ) {
+    public DependencyLoader( final DependencyLoaderView view,
+                             final Caller<DependencyService> dependencyService ) {
+        this.view = view;
         this.dependencyService = dependencyService;
     }
 
@@ -70,10 +74,13 @@ public class DependencyLoader {
 
     private void loadFromServer() {
 
+        view.showBusyIndicator( CommonConstants.INSTANCE.Loading() );
+
         dependencyService.call( new RemoteCallback<EnhancedDependencies>() {
                                     @Override
                                     public void callback( final EnhancedDependencies result ) {
                                         onLoadSuccess( result );
+                                        view.hideBusyIndicator();
                                     }
                                 },
                                 new ErrorCallback<Object>() {
@@ -83,6 +90,7 @@ public class DependencyLoader {
 
 
                                         returnDefault();
+                                        view.hideBusyIndicator();
                                         return false;
                                     }
                                 } ).loadEnhancedDependencies( updateQueue );

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderView.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderView.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
+
+public interface DependencyLoaderView
+        extends HasBusyIndicator {
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderViewImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+
+import org.uberfire.ext.widgets.common.client.common.BusyPopup;
+
+public class DependencyLoaderViewImpl
+        implements DependencyLoaderView {
+
+    @Override
+    public void showBusyIndicator( final String message ) {
+        BusyPopup.showMessage( message );
+    }
+
+    @Override
+    public void hideBusyIndicator() {
+        BusyPopup.close();
+    }
+}

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderLoadFailureTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderLoadFailureTest.java
@@ -16,6 +16,8 @@
 
 package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
 
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.guvnor.common.services.project.model.Dependency;
 import org.guvnor.common.services.project.model.GAV;
 import org.jboss.errai.common.client.api.Caller;
@@ -26,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.shared.dependencies.DependencyService;
 import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -33,8 +36,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( GwtMockitoTestRunner.class )
 public class DependencyLoaderLoadFailureTest {
+
+    @GwtMock
+    private CommonConstants commonConstants;
 
     @Mock
     private EnhancedDependenciesManager manager;
@@ -45,11 +51,15 @@ public class DependencyLoaderLoadFailureTest {
     @Mock
     private DependencyService dependencyService;
 
+    @Mock
+    private DependencyLoaderView view;
+
     private DependencyLoader dependencyLoader;
 
     @Before
     public void setUp() throws Exception {
-        dependencyLoader = new DependencyLoader( dependencyServiceCaller );
+        dependencyLoader = new DependencyLoader( view,
+                                                 dependencyServiceCaller );
         dependencyLoader.init( manager );
 
         when( dependencyServiceCaller.call( any( RemoteCallback.class ),
@@ -66,6 +76,9 @@ public class DependencyLoaderLoadFailureTest {
         failLoad();
 
         final EnhancedDependencies enhancedDependencies = getUpdatedEnhancedDependencies();
+
+        verify( view ).showBusyIndicator( "Loading" );
+        verify( view ).hideBusyIndicator();
 
         assertEquals( 1, enhancedDependencies.size() );
         assertNotNull( enhancedDependencies.get( new GAV( "org.junit", "junit", "1.0" ) ) );

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/DependencyLoaderTest.java
@@ -16,22 +16,27 @@
 
 package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
 
-import org.guvnor.common.services.project.model.Dependency;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.shared.dependencies.DependencyService;
 import org.kie.workbench.common.services.shared.dependencies.EnhancedDependencies;
+import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.mocks.CallerMock;
 
 import static org.junit.Assert.*;
+import static org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.Util.*;
 import static org.mockito.Mockito.*;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith( GwtMockitoTestRunner.class )
 public class DependencyLoaderTest {
+
+    @GwtMock
+    private CommonConstants commonConstants;
 
     @Mock
     private EnhancedDependenciesManager manager;
@@ -39,12 +44,17 @@ public class DependencyLoaderTest {
     @Mock
     private DependencyService dependencyService;
 
+    @Mock
+    private DependencyLoaderView view;
+
+
     private DependencyLoader dependencyLoader;
 
     @Before
     public void setUp() throws Exception {
 
-        dependencyLoader = new DependencyLoader( new CallerMock<DependencyService>( dependencyService ) );
+        dependencyLoader = new DependencyLoader( view,
+                                                 new CallerMock<DependencyService>( dependencyService ) );
         dependencyLoader.init( manager );
     }
 
@@ -67,18 +77,11 @@ public class DependencyLoaderTest {
 
         dependencyLoader.load();
 
+        verify( view ).showBusyIndicator( "Loading" );
+        verify( view ).hideBusyIndicator();
+
         final EnhancedDependencies updatedEnhancedDependencies = getUpdatedEnhancedDependencies();
         assertEquals( enhancedDependencies, updatedEnhancedDependencies );
-    }
-
-    private Dependency makeDependency( final String artifactId,
-                                       final String groupId,
-                                       final String version ) {
-        final Dependency dependency = new Dependency();
-        dependency.setArtifactId( artifactId );
-        dependency.setGroupId( groupId );
-        dependency.setVersion( version );
-        return dependency;
     }
 
     private EnhancedDependencies getUpdatedEnhancedDependencies() {

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager_onEchancedDependenciesLoadedTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/EnhancedDependenciesManager_onEchancedDependenciesLoadedTest.java
@@ -33,6 +33,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.client.callbacks.Callback;
 
 import static org.junit.Assert.*;
+import static org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.Util.makeDependency;
 import static org.mockito.Mockito.*;
 
 @RunWith( MockitoJUnitRunner.class )
@@ -120,13 +121,4 @@ public class EnhancedDependenciesManager_onEchancedDependenciesLoadedTest {
         assertFalse( originalSetOfDependencies.contains( junit ) );
     }
 
-    private Dependency makeDependency( final String artifactId,
-                                       final String groupId,
-                                       final String version ) {
-        final Dependency dependency = new Dependency();
-        dependency.setArtifactId( artifactId );
-        dependency.setGroupId( groupId );
-        dependency.setVersion( version );
-        return dependency;
-    }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/Util.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/forms/dependencies/Util.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.screens.projecteditor.client.forms.dependencies;
+
+
+import org.guvnor.common.services.project.model.Dependency;
+
+class Util {
+
+    public static Dependency makeDependency( final String artifactId,
+                                             final String groupId,
+                                             final String version ) {
+        final Dependency dependency = new Dependency();
+        dependency.setArtifactId( artifactId );
+        dependency.setGroupId( groupId );
+        dependency.setVersion( version );
+        return dependency;
+    }
+
+}


### PR DESCRIPTION
RHBRMS-2516 : When importing external projects, the dependency are not taken and at application server also

(cherry picked from commit 0c4d7bb12678cfaffa1523a4f2416ba07d7ab029)

99% the same as the fix for GUVNOR-2508

https://issues.jboss.org/browse/RHBRMS-2516
https://issues.jboss.org/browse/GUVNOR-2508