### PR TITLE
GUVNOR-2707: Guided Decision Table Editor: Overview Page throws an exception unless a Version is explicitly selected

### DIFF
--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditor.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/main/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditor.java
@@ -67,7 +67,8 @@ import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopu
  * {@link KieDocument} documents are first registered and then activated. Registration ensures the document
  * is configured for optimistic concurrent lock handling. Activation updates the content of the editor to
  * reflect the active document.
- * @param <D> Document type
+ * @param <D>
+ *         Document type
  */
 public abstract class KieMultipleDocumentEditor<D extends KieDocument> implements KieMultipleDocumentEditorPresenter<D> {
 
@@ -362,7 +363,7 @@ public abstract class KieMultipleDocumentEditor<D extends KieDocument> implement
         kieEditorWrapperView.addMainEditorPage( editorView );
 
         kieEditorWrapperView.addOverviewPage( overviewWidget,
-                                              () -> overviewWidget.refresh( document.getVersion() ) );
+                                              () -> overviewWidget.refresh( versionRecordManager.getVersion() ) );
 
         kieEditorWrapperView.addSourcePage( sourceWidget );
 
@@ -587,7 +588,7 @@ public abstract class KieMultipleDocumentEditor<D extends KieDocument> implement
     //Package protected to allow overriding for Unit Tests
     void doSave( final D document ) {
         savePopUpPresenter.show( document.getCurrentPath(),
-                                   getSaveCommand( document ) );
+                                 getSaveCommand( document ) );
     }
 
     //Package protected to allow overriding for Unit Tests

--- a/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorTest.java
+++ b/kie-wb-common-widgets/kie-wb-metadata-widget/src/test/java/org/kie/workbench/common/widgets/metadata/client/KieMultipleDocumentEditorTest.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import javax.enterprise.event.Event;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
@@ -652,6 +651,26 @@ public class KieMultipleDocumentEditorTest {
                 times( 1 ) ).setReadOnly( eq( true ) );
         verify( editor,
                 times( 1 ) ).refreshDocument( document );
+    }
+
+    @Test
+    public void verifyOverviewPageUsesVersionManagerVersion() {
+        final TestDocument document = createTestDocument();
+
+        registerDocument( document );
+        activateDocument( document );
+
+        final ArgumentCaptor<com.google.gwt.user.client.Command> onFocusCommandCaptor = ArgumentCaptor.forClass( com.google.gwt.user.client.Command.class );
+        verify( kieEditorWrapperView,
+                times( 1 ) ).addOverviewPage( any( OverviewWidgetPresenter.class ),
+                                              onFocusCommandCaptor.capture() );
+
+        final com.google.gwt.user.client.Command onFocusCommand = onFocusCommandCaptor.getValue();
+        assertNotNull( onFocusCommand );
+        onFocusCommand.execute();
+
+        verify( versionRecordManager,
+                times( 1 ) ).getVersion();
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2707

Retrieve the version for the "Overview Screen" from the ```VersionRecordManager``` instead of from the active "Document". This is how regular ```KieEditors``` pass the Version to the "Overview Screen".