### PR TITLE
[6.5.x] RHBRMS-2610: Guided Decision Table Editor: Add support for caching enumeration lookups

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/CachingEnumDropDownUtilities.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/CachingEnumDropDownUtilities.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.widget;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.gwt.core.client.Scheduler;
+import org.drools.workbench.models.datamodel.oracle.DropDownData;
+import org.gwtbootstrap3.client.ui.ListBox;
+import org.jboss.errai.bus.client.api.BusErrorCallback;
+import org.jboss.errai.bus.client.api.base.MessageBuilder;
+import org.jboss.errai.bus.client.api.messaging.Message;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.kie.workbench.common.services.shared.enums.EnumDropdownService;
+import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.widgets.common.client.common.BusyPopup;
+
+public class CachingEnumDropDownUtilities extends EnumDropDownUtilities {
+
+    static final Map<String, String[]> enumCache = new HashMap<String, String[]>();
+    static final Map<String, Set<ListBox>> pendingListBoxesCache = new HashMap<String, Set<ListBox>>();
+
+    @Override
+    public void setDropDownData( final String value,
+                                 final DropDownData dropData,
+                                 final boolean isMultipleSelect,
+                                 final Path resource,
+                                 final ListBox listBox ) {
+        if ( dropData == null ) {
+            fillDropDown( value,
+                          new String[ 0 ],
+                          isMultipleSelect,
+                          listBox );
+            return;
+        }
+
+        //Lookup data from definition if the list of enumerations comes from the definition itself
+        if ( dropData.getFixedList() != null ) {
+            getEnumsFromFixedList( value,
+                                   dropData,
+                                   isMultipleSelect,
+                                   listBox );
+            return;
+        }
+
+        //Lookup data from server if the list of enumerations comes from an external query
+        if ( dropData.getQueryExpression() != null ) {
+            getEnumsFromServer( value,
+                                dropData,
+                                isMultipleSelect,
+                                resource,
+                                listBox );
+        }
+    }
+
+    @Override
+    //Needs to be public for Unit Tests use of 'spy(..)'
+    public void fillDropDown( final String value,
+                              final DropDownData dropData,
+                              final boolean isMultipleSelect,
+                              final ListBox listBox ) {
+        super.fillDropDown( value,
+                            dropData,
+                            isMultipleSelect,
+                            listBox );
+    }
+
+    @Override
+    //Needs to be public for Unit Tests use of 'spy(..)'
+    public void fillDropDown( final String value,
+                              final String[] enumeratedValues,
+                              final boolean isMultipleSelect,
+                              final ListBox listBox ) {
+        super.fillDropDown( value,
+                            enumeratedValues,
+                            isMultipleSelect,
+                            listBox );
+    }
+
+    private void getEnumsFromFixedList( final String value,
+                                        final DropDownData dropData,
+                                        final boolean isMultipleSelect,
+                                        final ListBox listBox ) {
+        final String key = buildKey( dropData );
+        if ( !enumCache.containsKey( key ) ) {
+            enumCache.put( key,
+                           dropData.getFixedList() );
+        }
+        fillDropDown( value,
+                      enumCache.get( key ),
+                      isMultipleSelect,
+                      listBox );
+    }
+
+    private void getEnumsFromServer( final String value,
+                                     final DropDownData dropData,
+                                     final boolean isMultipleSelect,
+                                     final Path resource,
+                                     final ListBox listBox ) {
+        final String key = buildKey( dropData );
+        if ( enumCache.containsKey( key ) ) {
+            final String[] items = enumCache.get( key );
+            if ( items.length == 0 ) {
+                if ( !pendingListBoxesCache.containsKey( key ) ) {
+                    pendingListBoxesCache.put( key,
+                                               new HashSet<ListBox>() );
+                }
+                final Set<ListBox> pendingListBoxes = pendingListBoxesCache.get( key );
+                pendingListBoxes.add( listBox );
+                return;
+
+            } else {
+                fillDropDown( value,
+                              items,
+                              isMultipleSelect,
+                              listBox );
+                return;
+            }
+        }
+
+        //Cache empty value to prevent recurrent calls to the server for the same data.
+        //All list boxes that need filling on subsequent requests are cached until the
+        //first request completes and then populated.
+        enumCache.put( key,
+                       new String[ 0 ] );
+
+        loadEnumsFromServer( key,
+                             value,
+                             dropData,
+                             isMultipleSelect,
+                             resource,
+                             listBox );
+    }
+
+    void loadEnumsFromServer( final String key,
+                              final String value,
+                              final DropDownData dropData,
+                              final boolean isMultipleSelect,
+                              final Path resource,
+                              final ListBox listBox ) {
+        Scheduler.get().scheduleDeferred( new com.google.gwt.user.client.Command() {
+            public void execute() {
+                BusyPopup.showMessage( CommonConstants.INSTANCE.RefreshingList() );
+
+                MessageBuilder.createCall( new RemoteCallback<String[]>() {
+                                               public void callback( final String[] response ) {
+                                                   enumsLoadedFromServer( key,
+                                                                          value,
+                                                                          isMultipleSelect,
+                                                                          listBox,
+                                                                          response );
+                                               }
+                                           },
+                                           new BusErrorCallback() {
+                                               @Override
+                                               public boolean error( Message message,
+                                                                     Throwable throwable ) {
+                                                   BusyPopup.close();
+                                                   return false;
+                                               }
+                                           },
+                                           EnumDropdownService.class ).loadDropDownExpression( resource,
+                                                                                               dropData.getValuePairs(),
+                                                                                               dropData.getQueryExpression() );
+            }
+        } );
+    }
+
+    void enumsLoadedFromServer( final String key,
+                                final String value,
+                                final boolean isMultipleSelect,
+                                final ListBox listBox,
+                                String[] response ) {
+        BusyPopup.close();
+
+        if ( response.length == 0 ) {
+            response = new String[]{ CommonConstants.INSTANCE.UnableToLoadList() };
+
+        } else {
+            final Set<ListBox> pendingListBoxes = pendingListBoxesCache.remove( key );
+            if ( !( pendingListBoxes == null || pendingListBoxes.isEmpty() ) ) {
+                for ( ListBox lb : pendingListBoxes ) {
+                    fillDropDown( value,
+                                  response,
+                                  isMultipleSelect,
+                                  lb );
+                }
+            }
+        }
+
+        enumCache.put( key,
+                       response );
+
+        fillDropDown( value,
+                      response,
+                      isMultipleSelect,
+                      listBox );
+    }
+
+    private String buildKey( final DropDownData enumDefinition ) {
+        if ( enumDefinition.getFixedList() != null ) {
+            return buildFixedListKey( enumDefinition.getFixedList() );
+        } else {
+            return buildQueryExpressionKey( enumDefinition.getQueryExpression(),
+                                            enumDefinition.getValuePairs() );
+        }
+    }
+
+    private String buildFixedListKey( final String[] items ) {
+        final StringBuilder sb = new StringBuilder();
+        for ( String item : items ) {
+            sb.append( item ).append( "#" );
+        }
+        final String key = sb.toString();
+        return key;
+    }
+
+    private String buildQueryExpressionKey( final String queryExpression,
+                                            final String[] items ) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append( queryExpression ).append( "#" );
+        sb.append( buildFixedListKey( items ) );
+        final String key = sb.toString();
+        return key;
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/EnumDropDownUtilities.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/widget/EnumDropDownUtilities.java
@@ -98,10 +98,10 @@ public class EnumDropDownUtilities {
 
     }
 
-    private void fillDropDown( final String value,
-                               final DropDownData dropData,
-                               final boolean isMultipleSelect,
-                               final ListBox listBox ) {
+    protected void fillDropDown( final String value,
+                                 final DropDownData dropData,
+                                 final boolean isMultipleSelect,
+                                 final ListBox listBox ) {
         if ( dropData == null ) {
             fillDropDown( value,
                           new String[ 0 ],
@@ -115,10 +115,10 @@ public class EnumDropDownUtilities {
         }
     }
 
-    private void fillDropDown( final String value,
-                               final String[] enumeratedValues,
-                               final boolean isMultipleSelect,
-                               final ListBox listBox ) {
+    protected void fillDropDown( final String value,
+                                 final String[] enumeratedValues,
+                                 final boolean isMultipleSelect,
+                                 final ListBox listBox ) {
 
         listBox.clear();
 

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/CachingEnumDropDownUtilitiesTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/widget/CachingEnumDropDownUtilitiesTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.widget;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.datamodel.oracle.DropDownData;
+import org.gwtbootstrap3.client.ui.ListBox;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class CachingEnumDropDownUtilitiesTest {
+
+    @Mock
+    Path path;
+
+    @Mock
+    ListBox listBox1;
+
+    @Mock
+    ListBox listBox2;
+
+    @Captor
+    private ArgumentCaptor<String[]> listBox1ItemsCaptor;
+
+    @Captor
+    private ArgumentCaptor<String[]> listBox2ItemsCaptor;
+
+    private CachingEnumDropDownUtilities enumDropDownUtilities;
+
+    private String[] response;
+
+    @Before
+    public void setup() {
+        CachingEnumDropDownUtilities.enumCache.clear();
+        CachingEnumDropDownUtilities.pendingListBoxesCache.clear();
+    }
+
+    private void setupCachingEnumDropDownUtilities( final boolean async ) {
+        final CachingEnumDropDownUtilities wrapped = new CachingEnumDropDownUtilities() {
+            @Override
+            void loadEnumsFromServer( final String key,
+                                      final String value,
+                                      final DropDownData dropData,
+                                      final boolean isMultipleSelect,
+                                      final Path resource,
+                                      final ListBox listBox ) {
+                if ( !async ) {
+                    enumsLoadedFromServer( key,
+                                           value,
+                                           isMultipleSelect,
+                                           listBox,
+                                           response );
+                }
+            }
+
+        };
+        this.enumDropDownUtilities = spy( wrapped );
+    }
+
+    @Test
+    public void checkNullDefinition() {
+        setupCachingEnumDropDownUtilities( false );
+
+        enumDropDownUtilities.setDropDownData( "",
+                                               null,
+                                               false,
+                                               path,
+                                               listBox1 );
+
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox1ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox1 ) );
+
+        final String[] listBoxItems = listBox1ItemsCaptor.getValue();
+        assertEquals( 0,
+                      listBoxItems.length );
+    }
+
+    @Test
+    public void checkEmptyDefinition() {
+        setupCachingEnumDropDownUtilities( false );
+
+        enumDropDownUtilities.setDropDownData( "",
+                                               DropDownData.create( new String[]{} ),
+                                               false,
+                                               path,
+                                               listBox1 );
+
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox1ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox1 ) );
+
+        final String[] listBoxItems = listBox1ItemsCaptor.getValue();
+        assertEquals( 0,
+                      listBoxItems.length );
+    }
+
+    @Test
+    public void checkFixedListDefinitionWithCaching() {
+        setupCachingEnumDropDownUtilities( false );
+
+        enumDropDownUtilities.setDropDownData( "",
+                                               DropDownData.create( new String[]{ "one" } ),
+                                               false,
+                                               path,
+                                               listBox1 );
+
+        enumDropDownUtilities.setDropDownData( "",
+                                               DropDownData.create( new String[]{ "one" } ),
+                                               false,
+                                               path,
+                                               listBox2 );
+
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox1ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox1 ) );
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox2ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox2 ) );
+
+        final String[] listBox1Items = listBox1ItemsCaptor.getValue();
+        assertEquals( 1,
+                      listBox1Items.length );
+        final String[] listBox2Items = listBox2ItemsCaptor.getValue();
+        assertEquals( 1,
+                      listBox2Items.length );
+
+        assertEquals( 1,
+                      CachingEnumDropDownUtilities.enumCache.size() );
+    }
+
+    @Test
+    public void checkQueryExpressionDefinitionWithCaching() {
+        setupCachingEnumDropDownUtilities( false );
+
+        response = new String[]{ "server-one" };
+        enumDropDownUtilities.setDropDownData( "",
+                                               DropDownData.create( "query", new String[]{ "one" } ),
+                                               false,
+                                               path,
+                                               listBox1 );
+        enumDropDownUtilities.setDropDownData( "",
+                                               DropDownData.create( "query", new String[]{ "one" } ),
+                                               false,
+                                               path,
+                                               listBox2 );
+
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox1ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox1 ) );
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox2ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox2 ) );
+
+        verify( enumDropDownUtilities,
+                times( 1 ) ).loadEnumsFromServer( any( String.class ),
+                                                  any( String.class ),
+                                                  any( DropDownData.class ),
+                                                  any( Boolean.class ),
+                                                  any( Path.class ),
+                                                  any( ListBox.class ) );
+
+        final String[] listBox1Items = listBox1ItemsCaptor.getValue();
+        assertEquals( 1,
+                      listBox1Items.length );
+        final String[] listBox2Items = listBox2ItemsCaptor.getValue();
+        assertEquals( 1,
+                      listBox2Items.length );
+
+        assertEquals( 1,
+                      CachingEnumDropDownUtilities.enumCache.size() );
+        assertEquals( 0,
+                      CachingEnumDropDownUtilities.pendingListBoxesCache.size() );
+    }
+
+    @Test
+    public void checkQueryExpressionDefinitionWithCachingSlowAsyncServerCalls() {
+        setupCachingEnumDropDownUtilities( true );
+
+        response = new String[]{ "server-one" };
+        enumDropDownUtilities.setDropDownData( "",
+                                               DropDownData.create( "query", new String[]{ "one" } ),
+                                               false,
+                                               path,
+                                               listBox1 );
+        enumDropDownUtilities.setDropDownData( "",
+                                               DropDownData.create( "query", new String[]{ "one" } ),
+                                               false,
+                                               path,
+                                               listBox2 );
+
+        final ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass( String.class );
+
+        verify( enumDropDownUtilities,
+                times( 1 ) ).loadEnumsFromServer( keyCaptor.capture(),
+                                                  any( String.class ),
+                                                  any( DropDownData.class ),
+                                                  any( Boolean.class ),
+                                                  any( Path.class ),
+                                                  any( ListBox.class ) );
+
+        //Emulate server call completing after request for multiple ListBoxes
+        final String key = keyCaptor.getValue();
+        enumDropDownUtilities.enumsLoadedFromServer( key,
+                                                     "",
+                                                     false,
+                                                     listBox1,
+                                                     response );
+
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox1ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox1 ) );
+        verify( enumDropDownUtilities,
+                times( 1 ) ).fillDropDown( eq( "" ),
+                                           listBox2ItemsCaptor.capture(),
+                                           eq( false ),
+                                           eq( listBox2 ) );
+
+        final String[] listBox1Items = listBox1ItemsCaptor.getValue();
+        assertEquals( 1,
+                      listBox1Items.length );
+        final String[] listBox2Items = listBox2ItemsCaptor.getValue();
+        assertEquals( 1,
+                      listBox2Items.length );
+
+        assertEquals( 1,
+                      CachingEnumDropDownUtilities.enumCache.size() );
+        assertEquals( 0,
+                      CachingEnumDropDownUtilities.pendingListBoxesCache.size() );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/AbstractProxyPopupDropDownListBox.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/AbstractProxyPopupDropDownListBox.java
@@ -29,7 +29,7 @@ import com.google.gwt.text.shared.SafeHtmlRenderer;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.datamodel.oracle.DropDownData;
 import org.gwtbootstrap3.client.ui.ListBox;
-import org.kie.workbench.common.widgets.client.widget.EnumDropDownUtilities;
+import org.kie.workbench.common.widgets.client.widget.CachingEnumDropDownUtilities;
 
 /**
  * A Popup drop-down Editor for use within AbstractProxyPopupDropDownEditCell
@@ -40,7 +40,7 @@ public abstract class AbstractProxyPopupDropDownListBox<C> implements ProxyPopup
     private final ListBox listBox;
     private final AbstractProxyPopupDropDownEditCell proxy;
 
-    final EnumDropDownUtilities utilities = new EnumDropDownUtilities() {
+    final CachingEnumDropDownUtilities utilities = new CachingEnumDropDownUtilities() {
         @Override
         protected int addItems( final ListBox listBox ) {
             return 0;

--- a/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDropDownEditCell.java
+++ b/kie-wb-common-widgets/kie-wb-decorated-grid-widget/src/main/java/org/kie/workbench/common/widgets/decoratedgrid/client/widget/cells/PopupDropDownEditCell.java
@@ -30,7 +30,7 @@ import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 import org.drools.workbench.models.datamodel.oracle.DropDownData;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.widget.EnumDropDownUtilities;
+import org.kie.workbench.common.widgets.client.widget.CachingEnumDropDownUtilities;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.CellTableDropDownDataValueMapProvider;
 
 /**
@@ -48,7 +48,7 @@ public class PopupDropDownEditCell extends
     private final AsyncPackageDataModelOracle dmo;
     private final CellTableDropDownDataValueMapProvider dropDownManager;
 
-    final EnumDropDownUtilities utilities = new EnumDropDownUtilities() {
+    final CachingEnumDropDownUtilities utilities = new CachingEnumDropDownUtilities() {
         @Override
         protected int addItems( final ListBox listBox ) {
             return 0;


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2610

This is the equivalent of https://github.com/droolsjbpm/drools-wb/pull/304 however due to the code-base differences between ```master``` and ```6.5.x``` the change is required in ```kie-wb-common``` (and was in essence a re-write of the fix!)