### PR TITLE
[6.5.x] GUVNOR-2718: Validate: Validating a rule with changes that have not been saved gives and error for duplicate rule name

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/validation/asset/ValidatorBuildService.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/validation/asset/ValidatorBuildService.java
@@ -124,6 +124,11 @@ public class ValidatorBuildService {
                 builder.build();
             }
             final Builder clone = builder.clone();
+            //First delete resource otherwise if the resource already had errors following builder.build()
+            //the incremental compilation will not report any additional errors and the resource will be
+            //considered valid.
+            clone.deleteResource( nioResourcePath );
+
             final IncrementalBuildResults incrementalBuildResults = clone.updateResource( nioResourcePath,
                                                                                           inputStream );
             resultBuilder.add( incrementalBuildResults.getAddedMessages() );

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/asset/DefaultGenericKieValidatorTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/asset/DefaultGenericKieValidatorTest.java
@@ -34,7 +34,7 @@ import org.uberfire.backend.vfs.Path;
 
 import static org.junit.Assert.*;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith(MockitoJUnitRunner.class)
 public class DefaultGenericKieValidatorTest {
 
     private TestFileSystem testFileSystem;
@@ -61,6 +61,23 @@ public class DefaultGenericKieValidatorTest {
                                                                    Resources.toString( urlToValidate, Charsets.UTF_8 ) );
 
         assertTrue( errors.isEmpty() );
+    }
+
+    @Test
+    public void validatingAnAlreadyInvalidAssetShouldReportErrors() throws Exception {
+        final Path path = resourcePath( "/BuilderExampleBrokenSyntax/src/main/resources/rule1.drl" );
+        final URL urlToValidate = this.getClass().getResource( "/BuilderExampleBrokenSyntax/src/main/resources/rule1.drl" );
+
+        final List<ValidationMessage> errors1 = validator.validate( path,
+                                                                    Resources.toString( urlToValidate, Charsets.UTF_8 ) );
+
+        final List<ValidationMessage> errors2 = validator.validate( path,
+                                                                    Resources.toString( urlToValidate, Charsets.UTF_8 ) );
+
+        assertFalse( errors1.isEmpty() );
+        assertFalse( errors2.isEmpty() );
+        assertEquals( errors1.size(),
+                      errors2.size() );
     }
 
     private Path resourcePath( final String resourceName ) throws URISyntaxException {


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2718

Note: This is a duplication of GUVNOR-2682 (which was fixed on master)

(cherry picked from commit 133dd6c60b7cd62eef56e70351d8fd06fa0c3d3e)