### PR TITLE
Remove duplicated deps in POMs

### DIFF
--- a/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/pom.xml
+++ b/kie-wb-common-forms/kie-wb-common-forms-editor/kie-wb-common-forms-editor-client/pom.xml
@@ -58,11 +58,6 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-ui</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
 

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
@@ -247,12 +247,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-test-utils</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/pom.xml
@@ -155,11 +155,6 @@
 
     <dependency>
       <groupId>org.guvnor</groupId>
-      <artifactId>guvnor-project-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.guvnor</groupId>
       <artifactId>guvnor-asset-mgmt-api</artifactId>
     </dependency>
 

--- a/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-search-screen/kie-wb-common-search-screen-api/pom.xml
@@ -30,10 +30,6 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-api</artifactId>
-    </dependency>
 
   </dependencies>
 

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
@@ -15,7 +15,6 @@
 
   <dependencies>
 
-    <!-- dependencies added because of new illegal transitive dependency check -->
     <dependency>
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-project-api</artifactId>
@@ -25,10 +24,6 @@
           <artifactId>uberfire-client-api</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.server</groupId>
-      <artifactId>kie-server-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>

--- a/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-social-home-page/kie-wb-common-social-home-page-client/pom.xml
@@ -111,11 +111,6 @@
       <artifactId>uberfire-client-all</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-testing-utils</artifactId>
-    </dependency>
-
     <!-- Test deps -->
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
The reason for these changes is that Maven 3.4.0 will fail the build in case of duplicated deps (instead of just logging WARNing message as previous versions).