### PR TITLE
server-ui-backend: direct dependency on kie-remote-common is not needed

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/pom.xml
@@ -85,12 +85,7 @@
       <artifactId>kie-server-controller-rest</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.kie.remote</groupId>
-      <artifactId>kie-remote-common</artifactId>
-    </dependency>
-
-    <dependency>
+      <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>


### PR DESCRIPTION
 * the code does not import any classes from there and it is being
   brought in transitively via kie-server-client