### PR TITLE
kie-wb-common-workbench-client: Update module descriptor after UF-320

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/KieDefaultWorkbenchClient.gwt.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/KieDefaultWorkbenchClient.gwt.xml
@@ -29,6 +29,7 @@
 
   <inherits name="org.uberfire.UberfireWorkbench"/>
   <inherits name="org.uberfire.ext.preferences.UberfirePreferences"/>
+  <inherits name="org.uberfire.ext.security.management.UberfireSecurityManagementClient"/>
 
   <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>
   <inherits name='org.gwtbootstrap3.extras.typeahead.Typeahead'/>


### PR DESCRIPTION
Fixes compilation issues after https://github.com/uberfire/uberfire/pull/541/ had been merged.

`[INFO]    Tracing compile failure path for type 'org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper'
[INFO]          [ERROR] Line 50: No source code is available for type org.uberfire.ext.security.management.client.ClientUserSystemManager; did you forget to inherit a required module?
[INFO]          [ERROR] Line 64: No source code is available for type org.uberfire.ext.security.management.api.AbstractEntityManager<T,S>.SearchResponse<T>; did you forget to inherit a required module?
[INFO]          [ERROR] Line 68: No source code is available for type org.uberfire.ext.security.management.impl.SearchRequestImpl; did you forget to inherit a required module?`
