### PR TITLE
GUVNOR-2735: Guided Decision Table Editor: When opening an empty 'Graph' the editor is not populated

### DIFF
--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelector.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelector.java
@@ -18,22 +18,25 @@ package org.kie.workbench.common.widgets.client.ruleselector;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.InlineLabel;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 
 public class RuleSelector
         extends Composite
-        implements HasValueChangeHandlers<String> {
+        implements HasValueChangeHandlers<String>,
+                   HasEnabled {
 
     private final HorizontalPanel panel = new HorizontalPanel();
     private final InlineLabel ruleNamePanel = new InlineLabel();
-    private final RuleSelectorDropdown ruleSelectorDropdown = new RuleSelectorDropdown();
+    private final RuleSelectorDropdown ruleSelectorDropdown = GWT.create( RuleSelectorDropdown.class );
 
     private final static String NONE_SELECTED = CommonConstants.INSTANCE.NoneSelected();
 
@@ -100,5 +103,16 @@ public class RuleSelector
     public HandlerRegistration addValueChangeHandler( final ValueChangeHandler<String> handler ) {
         return addHandler( handler,
                            ValueChangeEvent.getType() );
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return ruleSelectorDropdown.isEnabled();
+    }
+
+    @Override
+    public void setEnabled( final boolean enabled ) {
+        ruleSelectorDropdown.setEnabled( enabled );
+
     }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelectorDropdown.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelectorDropdown.java
@@ -17,6 +17,7 @@ package org.kie.workbench.common.widgets.client.ruleselector;
 
 import java.util.Collection;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
@@ -24,6 +25,7 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
@@ -36,13 +38,11 @@ import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 public class RuleSelectorDropdown
         extends Composite
         implements IsWidget,
-                   HasValueChangeHandlers<String> {
+                   HasValueChangeHandlers<String>,
+                   HasEnabled {
 
     private DropDown dropdown = new DropDown();
-    private Button dropdownButton = new Button() {{
-        setDataToggle( Toggle.DROPDOWN );
-        setToggleCaret( true );
-    }};
+    private Button dropdownButton = GWT.create( Button.class );
 
     private DropDownMenu dropdownMenu = new DropDownMenu();
 
@@ -51,6 +51,8 @@ public class RuleSelectorDropdown
         initWidget( dropdown );
         dropdown.add( dropdownButton );
         dropdown.add( dropdownMenu );
+        dropdownButton.setDataToggle( Toggle.DROPDOWN );
+        dropdownButton.setToggleCaret( true );
     }
 
     private void addNoneSelectionToDropDown() {
@@ -73,7 +75,8 @@ public class RuleSelectorDropdown
     }
 
     private AnchorListItem makeNoneLabel() {
-        final AnchorListItem label = new AnchorListItem( CommonConstants.INSTANCE.LineNoneLine() );
+        final AnchorListItem label = GWT.create( AnchorListItem.class );
+        label.setText( CommonConstants.INSTANCE.LineNoneLine() );
         label.addClickHandler( new ClickHandler() {
             @Override
             public void onClick( ClickEvent event ) {
@@ -95,6 +98,16 @@ public class RuleSelectorDropdown
     public HandlerRegistration addValueChangeHandler( final ValueChangeHandler<String> handler ) {
         return addHandler( handler,
                            ValueChangeEvent.getType() );
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return dropdownButton.isEnabled();
+    }
+
+    @Override
+    public void setEnabled( final boolean enabled ) {
+        dropdownButton.setEnabled( enabled );
     }
 
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelectorDropdownTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelectorDropdownTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.ruleselector;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.gwtbootstrap3.client.ui.AnchorListItem;
+import org.gwtbootstrap3.client.ui.Button;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub({ AnchorListItem.class })
+public class RuleSelectorDropdownTest {
+
+    @GwtMock
+    Button dropdownButton;
+
+    @Test
+    public void checkEnable() {
+        final RuleSelectorDropdown ruleSelectorDropdown = new RuleSelectorDropdown();
+        ruleSelectorDropdown.setEnabled( true );
+
+        verify( dropdownButton,
+                times( 1 ) ).setEnabled( true );
+    }
+
+    @Test
+    public void checkDisable() {
+        final RuleSelectorDropdown ruleSelectorDropdown = new RuleSelectorDropdown();
+        ruleSelectorDropdown.setEnabled( false );
+
+        verify( dropdownButton,
+                times( 1 ) ).setEnabled( false );
+    }
+
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelectorTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/ruleselector/RuleSelectorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.ruleselector;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class RuleSelectorTest {
+
+    @GwtMock
+    RuleSelectorDropdown ruleSelectorDropdown;
+
+    @Test
+    public void checkEnable() {
+        final RuleSelector ruleSelector = new RuleSelector();
+        ruleSelector.setEnabled( true );
+
+        verify( ruleSelectorDropdown,
+                times( 1 ) ).setEnabled( true );
+    }
+
+    @Test
+    public void checkDisable() {
+        final RuleSelector ruleSelector = new RuleSelector();
+        ruleSelector.setEnabled( false );
+
+        verify( ruleSelectorDropdown,
+                times( 1 ) ).setEnabled( false );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2735

This PR adds ```HasEnabled``` to the ```RuleSelector``` widget.