### PR TITLE
Ignore Stunner Showcase webapp

### DIFF
--- a/kie-wb-common-stunner/pom.xml
+++ b/kie-wb-common-stunner/pom.xml
@@ -38,7 +38,8 @@
         <module>kie-wb-common-stunner-backend</module>
         <module>kie-wb-common-stunner-client</module>
         <module>kie-wb-common-stunner-sets</module>
-        <module>kie-wb-common-stunner-showcase</module>
+        <!-- Ignored for now.. since it causes kie-wb-common to have a dependency on drools-wb. See BSIG mailing list -->
+        <!-- <module>kie-wb-common-stunner-showcase</module> -->
     </modules>
 
     <build>


### PR DESCRIPTION
Stunner Showcase causes a dependency of kie-wb-common on drools-wb, which is wrong.

See BSIG mailing list for details.