### PR TITLE
JBPM-5394: Removing wrong dependencies to drools-wb assets.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/pom.xml
@@ -736,14 +736,23 @@
         </dependency>
 
         <dependency>
-            <groupId>org.drools</groupId>
-            <artifactId>drools-wb-workitems-editor-client</artifactId>
-            <scope>provided</scope>
+            <groupId>org.kie.workbench.services</groupId>
+            <artifactId>kie-wb-common-datamodel-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.drools</groupId>
-            <artifactId>drools-wb-workitems-editor-backend</artifactId>
+            <artifactId>drools-workbench-models-datamodel-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kie.workbench.screens</groupId>
+            <artifactId>kie-wb-common-default-editor-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-bpmn2</artifactId>
         </dependency>
 
         <dependency>
@@ -766,6 +775,11 @@
         <dependency>
             <groupId>org.kie.workbench.screens</groupId>
             <artifactId>kie-wb-common-project-explorer-backend</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.kie.workbench.screens</groupId>
+            <artifactId>kie-wb-common-project-editor-api</artifactId>
         </dependency>
 
         <dependency>
@@ -995,7 +1009,9 @@
                         <compileSourcesArtifact>org.uberfire:uberfire-security-management-client-wb</compileSourcesArtifact>
                         <compileSourcesArtifact>org.uberfire:uberfire-widgets-security-management</compileSourcesArtifact>
 
-                        <!-- Guvnor. -->
+                        <!-- Drools & Guvnor. -->
+                        <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-datamodel-api</compileSourcesArtifact>
+                        <compileSourcesArtifact>org.drools:drools-workbench-models-datamodel-api</compileSourcesArtifact>
                         <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-api</compileSourcesArtifact>
                         <compileSourcesArtifact>org.guvnor:guvnor-asset-mgmt-client</compileSourcesArtifact>
                         <compileSourcesArtifact>org.guvnor:guvnor-structure-api</compileSourcesArtifact>
@@ -1025,7 +1041,6 @@
                         <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-config-resource-widget</compileSourcesArtifact>
                         <compileSourcesArtifact>org.kie.workbench.widgets:kie-wb-decorated-grid-widget</compileSourcesArtifact>
                         <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-services-api</compileSourcesArtifact>
-                        <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-datamodel-api</compileSourcesArtifact>
                         <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-refactoring-api</compileSourcesArtifact>
                         <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-api</compileSourcesArtifact>
                         <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-java-editor-client</compileSourcesArtifact>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectShowcase.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-project/src/main/resources/org/kie/workbench/common/stunner/project/StunnerProjectShowcase.gwt.xml
@@ -41,18 +41,15 @@
   <inherits name="org.guvnor.asset.management.GuvnorAssetMgmtAPI"/>
   <inherits name='org.guvnor.asset.management.GuvnorAssetMgmtClient'/>
 
-  <!--Common Screens -->
+  <!--Common Screens and services. -->
+  <inherits name="org.kie.workbench.common.services.datamodel.KieWorkbenchCommonDataModelAPI"/>
+  <inherits name="org.kie.workbench.common.screens.defaulteditor.DroolsWorkbenchDefaultEditorClient"/>
   <inherits name="org.kie.workbench.common.screens.explorer.KieWorkbenchProjectExplorerClient"/>
   <inherits name="org.kie.workbench.common.screens.projecteditor.KieWorkbenchCommonProjectEditorClient"/>
   <inherits name="org.kie.workbench.common.screens.projectimportsscreen.KieWorkbenchCommonProjectImportsScreenClient"/>
   <inherits name="org.kie.workbench.common.workbench.KieDefaultWorkbenchClient"/>
-
   <inherits name="org.kie.workbench.common.services.datamodeller.DataModellerCore" />
   <inherits name="org.kie.workbench.common.screens.datamodeller.KieWorkbenchDatamodellerClient"/>
-  <inherits name="org.drools.workbench.screens.workitems.DroolsWorkbenchWorkItemsEditorClient"/>
-  <inherits name="org.kie.workbench.common.screens.defaulteditor.DroolsWorkbenchDefaultEditorClient"/>
-
-  <!-- Common Services -->
   <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>
   <inherits name='org.kie.workbench.common.services.KieWorkbenchCommonServicesAPI'/>
   <inherits name="org.kie.workbench.common.widgets.metadata.KieWorkbenchMetadataWidget"/>
@@ -71,13 +68,6 @@
   <!-- Form modeler.-->
   <inherits name="org.kie.workbench.common.stunner.forms.StunnerFormsClient"/>
   <inherits name="org.kie.workbench.common.forms.dynamic.DynamicFormsClient"/>
-  <inherits name="org.kie.workbench.common.forms.common.rendering.CommonFormClient"/>
-  <inherits name="org.hibernate.validator.HibernateValidator" />
-  <inherits name="org.jboss.errai.validation.Validation" />
-  <generate-with class="org.jboss.errai.validation.rebind.ValidatorFactoryGenerator">
-    <when-type-assignable
-            class="javax.validation.ValidatorFactory"/>
-  </generate-with>
 
   <extend-property name="locale" values="es"/>
   <extend-property name="locale" values="fr"/>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/pom.xml
@@ -558,6 +558,21 @@
             <classifier>sources</classifier>
         </dependency>
 
+        <dependency>
+            <groupId>org.kie.workbench.services</groupId>
+            <artifactId>kie-wb-common-datamodel-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-workbench-models-datamodel-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-bpmn2</artifactId>
+        </dependency>
+
         <!-- UberFire Plugins Extension -->
 
         <dependency>
@@ -686,7 +701,7 @@
 
                 <compileSourcesArtifacts>
 
-                    <!-- UberFire -->
+                    <!-- UberFire, Errai & Drools. -->
                     <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>
                     <compileSourcesArtifact>org.uberfire:uberfire-nio2-model</compileSourcesArtifact>
                     <compileSourcesArtifact>org.uberfire:uberfire-io</compileSourcesArtifact>
@@ -701,6 +716,8 @@
                     <compileSourcesArtifact>org.uberfire:uberfire-simple-docks-client</compileSourcesArtifact>
                     <compileSourcesArtifact>org.uberfire:uberfire-backend-api</compileSourcesArtifact>
                     <compileSourcesArtifact>org.jboss.errai:errai-data-binding</compileSourcesArtifact>
+                    <compileSourcesArtifact>org.kie.workbench.services:kie-wb-common-datamodel-api</compileSourcesArtifact>
+                    <compileSourcesArtifact>org.drools:drools-workbench-models-datamodel-api</compileSourcesArtifact>
 
                     <!-- UF-ext -->
                     <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-api</compileSourcesArtifact>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/StunnerStandaloneShowcase.gwt.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-showcase/kie-wb-common-stunner-showcase-standalone/src/main/resources/org/kie/workbench/common/stunner/standalone/StunnerStandaloneShowcase.gwt.xml
@@ -25,6 +25,8 @@
   <inherits name="org.uberfire.client.views.PatternFlyTheme"/>
   <inherits name="org.uberfire.ext.plugin.RuntimePluginClient"/>
   <inherits name="org.uberfire.ext.apps.UberfireAppsClient"/>
+  <inherits name="org.kie.workbench.common.services.datamodel.KieWorkbenchCommonDataModelAPI"/>
+  <inherits name="org.drools.workbench.models.datamodel.DroolsWorkbenchDataModelAPI"/>
   <inherits name="org.uberfire.ext.security.management.UberfireSecurityManagementWorkbench"/>
 
   <!-- Stunner.-->
@@ -35,13 +37,6 @@
   <!-- Form modeler.-->
   <inherits name="org.kie.workbench.common.stunner.forms.StunnerFormsClient"/>
   <inherits name="org.kie.workbench.common.forms.dynamic.DynamicFormsClient"/>
-  <inherits name="org.kie.workbench.common.forms.common.rendering.CommonFormClient"/>
-  <inherits name="org.hibernate.validator.HibernateValidator" />
-  <inherits name="org.jboss.errai.validation.Validation" />
-  <generate-with class="org.jboss.errai.validation.rebind.ValidatorFactoryGenerator">
-    <when-type-assignable
-            class="javax.validation.ValidatorFactory"/>
-  </generate-with>
 
   <extend-property name="locale" values="es"/>
   <extend-property name="locale" values="fr"/>

--- a/kie-wb-common-stunner/pom.xml
+++ b/kie-wb-common-stunner/pom.xml
@@ -38,8 +38,7 @@
         <module>kie-wb-common-stunner-backend</module>
         <module>kie-wb-common-stunner-client</module>
         <module>kie-wb-common-stunner-sets</module>
-        <!-- Ignored for now.. since it causes kie-wb-common to have a dependency on drools-wb. See BSIG mailing list -->
-        <!-- <module>kie-wb-common-stunner-showcase</module> -->
+        <module>kie-wb-common-stunner-showcase</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Hi @csadilek @manstis @Rikkola ,
Here is the fix for the showcase modules. In fact the dependency to the drools-wb was not necessry, it was my mistake, sorry guys. I have done a complete review for the dependencies, fixed some and hope no more issues due to this will appear... sorry for the inconveniences again.
See https://issues.jboss.org/browse/JBPM-5394
Thanks!