### PR TITLE
JBPM-5391: Use of Iterable instead Collection for the command API and related components. Fixed some bugs as well.

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/Notifications.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/main/java/org/kie/workbench/common/stunner/client/widgets/notification/Notifications.java
@@ -239,7 +239,7 @@ public class Notifications implements IsWidget {
             final CanvasHandler canvasHandler = commandExecutedEvent.getCanvasHandler();
             final Command<CanvasHandler, CanvasViolation> command =
                     ( Command<CanvasHandler, CanvasViolation> ) commandExecutedEvent.getCommand();
-            final Collection<? extends Command<? extends CanvasHandler, CanvasViolation>> commands = commandExecutedEvent.getCommands();
+            final Iterable<? extends Command<? extends CanvasHandler, CanvasViolation>> commands = commandExecutedEvent.getCommands();
             final CommandResult<CanvasViolation> result = commandExecutedEvent.getResult();
             return new CanvasCommandNotification.CanvasCommandNotificationBuilder<CanvasHandler>()
                     .canvasHander( canvasHandler )

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/AbstractCanvasCommandEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/AbstractCanvasCommandEvent.java
@@ -23,11 +23,10 @@ import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 
 import java.util.ArrayList;
-import java.util.Collection;
 
 public abstract class AbstractCanvasCommandEvent<H extends CanvasHandler> extends AbstractCanvasHandlerEvent<H> {
 
-    private final Collection<Command<H, CanvasViolation>> commands;
+    private final Iterable<Command<H, CanvasViolation>> commands;
     private final boolean isBatch;
     private final CommandResult<CanvasViolation> result;
 
@@ -43,7 +42,7 @@ public abstract class AbstractCanvasCommandEvent<H extends CanvasHandler> extend
     }
 
     public AbstractCanvasCommandEvent( final H canvasHandler,
-                                       final Collection<Command<H, CanvasViolation>> commands,
+                                       final Iterable<Command<H, CanvasViolation>> commands,
                                        final CommandResult<CanvasViolation> result ) {
         super( canvasHandler );
         this.commands = commands;
@@ -55,7 +54,7 @@ public abstract class AbstractCanvasCommandEvent<H extends CanvasHandler> extend
         return isBatch ? null : commands.iterator().next();
     }
 
-    public Collection<Command<H, CanvasViolation>> getCommands() {
+    public Iterable<Command<H, CanvasViolation>> getCommands() {
         return isBatch ? commands : null;
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/CanvasCommandAllowedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/CanvasCommandAllowedEvent.java
@@ -21,7 +21,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 
-import java.util.Collection;
 
 public final class CanvasCommandAllowedEvent<H extends CanvasHandler> extends AbstractCanvasCommandEvent<H> {
 
@@ -32,7 +31,7 @@ public final class CanvasCommandAllowedEvent<H extends CanvasHandler> extends Ab
     }
 
     public CanvasCommandAllowedEvent( final H canvasHandler,
-                                      final Collection<Command<H, CanvasViolation>> commands,
+                                      final Iterable<Command<H, CanvasViolation>> commands,
                                       final CommandResult<CanvasViolation> result ) {
         super( canvasHandler, commands, result );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/CanvasCommandExecutedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/CanvasCommandExecutedEvent.java
@@ -21,7 +21,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 
-import java.util.Collection;
 
 public final class CanvasCommandExecutedEvent<H extends CanvasHandler> extends AbstractCanvasCommandEvent<H> {
 
@@ -32,7 +31,7 @@ public final class CanvasCommandExecutedEvent<H extends CanvasHandler> extends A
     }
 
     public CanvasCommandExecutedEvent( final H canvasHandler,
-                                       final Collection<Command<H, CanvasViolation>> commands,
+                                       final Iterable<Command<H, CanvasViolation>> commands,
                                        final CommandResult<CanvasViolation> result ) {
         super( canvasHandler, commands, result );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/CanvasUndoCommandExecutedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-client-api/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/event/command/CanvasUndoCommandExecutedEvent.java
@@ -21,8 +21,6 @@ import org.kie.workbench.common.stunner.core.client.command.CanvasViolation;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 
-import java.util.Collection;
-
 public final class CanvasUndoCommandExecutedEvent<H extends CanvasHandler> extends AbstractCanvasCommandEvent<H> {
 
     public CanvasUndoCommandExecutedEvent( final H canvasHandler,
@@ -32,7 +30,7 @@ public final class CanvasUndoCommandExecutedEvent<H extends CanvasHandler> exten
     }
 
     public CanvasUndoCommandExecutedEvent( final H canvasHandler,
-                                           final Collection<Command<H, CanvasViolation>> commands,
+                                           final Iterable<Command<H, CanvasViolation>> commands,
                                            final CommandResult<CanvasViolation> result ) {
         super( canvasHandler, commands, result );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/batch/BatchCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/batch/BatchCommandManager.java
@@ -19,8 +19,6 @@ package org.kie.workbench.common.stunner.core.command.batch;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManager;
 
-import java.util.Collection;
-
 /**
  * Manager to handle batched execution of commands.
  */
@@ -43,6 +41,6 @@ public interface BatchCommandManager<T, V> extends CommandManager<T, V> {
      */
     BatchCommandResult<V> undoBatch( T context );
 
-    Collection<Command<T, V>> getBatchCommands();
+    Iterable<Command<T, V>> getBatchCommands();
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/batch/BatchCommandManagerListener.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/batch/BatchCommandManagerListener.java
@@ -20,12 +20,10 @@ import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandManagerListener;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 
-import java.util.Collection;
-
 public interface BatchCommandManagerListener<T, V> extends CommandManagerListener<T, V> {
 
-    void onExecuteBatch( T context, Collection<Command<T, V>> commands, BatchCommandResult<V> result );
+    void onExecuteBatch( T context, Iterable<Command<T, V>> commands, BatchCommandResult<V> result );
 
-    void onUndoBatch( T context, Collection<Command<T, V>> commands, CommandResult<V> result );
+    void onUndoBatch( T context, Iterable<Command<T, V>> commands, CommandResult<V> result );
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/delegate/BatchDelegateCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/delegate/BatchDelegateCommandManager.java
@@ -46,7 +46,7 @@ public abstract class BatchDelegateCommandManager<C, V> extends DelegateCommandM
 
         @Override
         public void onExecuteBatch( final C context,
-                                    final Collection<Command<C, V>> commands,
+                                    final Iterable<Command<C, V>> commands,
                                     final BatchCommandResult<V> result ) {
             postExecuteBatch( context, commands, result );
 
@@ -54,7 +54,7 @@ public abstract class BatchDelegateCommandManager<C, V> extends DelegateCommandM
 
         @Override
         public void onUndoBatch( final C context,
-                                 final Collection<Command<C, V>> commands,
+                                 final Iterable<Command<C, V>> commands,
                                  final CommandResult<V> result ) {
             postUndo( context, commands, result );
 
@@ -83,7 +83,7 @@ public abstract class BatchDelegateCommandManager<C, V> extends DelegateCommandM
     }
 
     @Override
-    public Collection<Command<C, V>> getBatchCommands() {
+    public Iterable<Command<C, V>> getBatchCommands() {
         return getBatchDelegate().getBatchCommands();
     }
 
@@ -115,12 +115,12 @@ public abstract class BatchDelegateCommandManager<C, V> extends DelegateCommandM
     }
 
     protected void postExecuteBatch( final C context,
-                                     final Collection<Command<C, V>> commands,
+                                     final Iterable<Command<C, V>> commands,
                                      final BatchCommandResult<V> result ) {
     }
 
     protected void postUndo( final C context,
-                             final Collection<Command<C, V>> commands,
+                             final Iterable<Command<C, V>> commands,
                              final CommandResult<V> result ) {
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/AbstractCommandEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/AbstractCommandEvent.java
@@ -20,15 +20,14 @@ import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 
 import java.util.ArrayList;
-import java.util.Collection;
 
 public abstract class AbstractCommandEvent<C, V> {
 
-    private final Collection<Command<C, V>> commands;
+    private final Iterable<Command<C, V>> commands;
     private final boolean isBatch;
     private final CommandResult<V> result;
 
-    public AbstractCommandEvent( final Collection<Command<C, V>> commands,
+    public AbstractCommandEvent( final Iterable<Command<C, V>> commands,
                                  final CommandResult<V> result ) {
         this.commands = commands;
         this.isBatch = true;
@@ -51,7 +50,7 @@ public abstract class AbstractCommandEvent<C, V> {
         return null;
     }
 
-    public Collection<Command<C, V>> getCommands() {
+    public Iterable<Command<C, V>> getCommands() {
         if ( isBatch ) {
             return commands;
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/AbstractGraphCommandEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/AbstractGraphCommandEvent.java
@@ -21,8 +21,6 @@ import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-import java.util.Collection;
-
 public abstract class AbstractGraphCommandEvent extends AbstractCommandEvent<GraphCommandExecutionContext, RuleViolation> {
 
     public AbstractGraphCommandEvent( final Command<GraphCommandExecutionContext, RuleViolation> command,
@@ -30,7 +28,7 @@ public abstract class AbstractGraphCommandEvent extends AbstractCommandEvent<Gra
         super( command, result );
     }
 
-    public AbstractGraphCommandEvent( final Collection<Command<GraphCommandExecutionContext, RuleViolation>> commands,
+    public AbstractGraphCommandEvent( final Iterable<Command<GraphCommandExecutionContext, RuleViolation>> commands,
                                       final CommandResult<RuleViolation> result ) {
         super( commands, result );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/local/CommandExecutedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/local/CommandExecutedEvent.java
@@ -23,8 +23,6 @@ import org.kie.workbench.common.stunner.core.command.event.AbstractGraphCommandE
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-import java.util.Collection;
-
 @NonPortable
 public final class CommandExecutedEvent extends AbstractGraphCommandEvent {
 
@@ -33,7 +31,7 @@ public final class CommandExecutedEvent extends AbstractGraphCommandEvent {
         super( command, result );
     }
 
-    public CommandExecutedEvent( final Collection<Command<GraphCommandExecutionContext, RuleViolation>> commands,
+    public CommandExecutedEvent( final Iterable<Command<GraphCommandExecutionContext, RuleViolation>> commands,
                                  final CommandResult<RuleViolation> result ) {
         super( commands, result );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/local/CommandUndoExecutedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/local/CommandUndoExecutedEvent.java
@@ -23,8 +23,6 @@ import org.kie.workbench.common.stunner.core.command.event.AbstractGraphCommandE
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-import java.util.Collection;
-
 @NonPortable
 public final class CommandUndoExecutedEvent extends AbstractGraphCommandEvent {
 
@@ -33,7 +31,7 @@ public final class CommandUndoExecutedEvent extends AbstractGraphCommandEvent {
         super( command, result );
     }
 
-    public CommandUndoExecutedEvent( final Collection<Command<GraphCommandExecutionContext, RuleViolation>> commands,
+    public CommandUndoExecutedEvent( final Iterable<Command<GraphCommandExecutionContext, RuleViolation>> commands,
                                      final CommandResult<RuleViolation> result ) {
         super( commands, result );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/local/IsCommandAllowedEvent.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/command/event/local/IsCommandAllowedEvent.java
@@ -23,8 +23,6 @@ import org.kie.workbench.common.stunner.core.command.event.AbstractGraphCommandE
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
-import java.util.Collection;
-
 @NonPortable
 public final class IsCommandAllowedEvent extends AbstractGraphCommandEvent {
 
@@ -33,7 +31,7 @@ public final class IsCommandAllowedEvent extends AbstractGraphCommandEvent {
         super( command, result );
     }
 
-    public IsCommandAllowedEvent( final Collection<Command<GraphCommandExecutionContext, RuleViolation>> commands,
+    public IsCommandAllowedEvent( final Iterable<Command<GraphCommandExecutionContext, RuleViolation>> commands,
                                   final CommandResult<RuleViolation> result ) {
         super( commands, result );
     }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/registry/command/CommandRegistry.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-api/kie-wb-common-stunner-core-api/src/main/java/org/kie/workbench/common/stunner/core/registry/command/CommandRegistry.java
@@ -29,22 +29,26 @@ import java.util.Collection;
 public interface CommandRegistry<C extends Command> extends DynamicRegistry<C>, SizeConstrainedRegistry {
 
     /**
-     * Registers a command.
+     * Registers a single or more than one command/s.
+     * The further iteration order for this collection matters.
      */
-    void register( Collection<C> command );
+    void register( Iterable<C> command );
 
     /**
      * Returns the registered commands, can be composed collections if they're batched.
+     * It must ensure the right iteration order as the commands have been executed.
      */
     Iterable<Iterable<C>> getCommandHistory();
 
     /**
      * Peek the command from the registry.
+     * It must ensure the right iteration order as the commands have been executed.
      */
     Iterable<C> peek();
 
     /**
      * Peek and remove the command from the registry.
+     * It must ensure the right iteration order as the commands have been executed.
      */
     Iterable<C> pop();
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/AbstractCanvasCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/AbstractCanvasCommand.java
@@ -18,14 +18,10 @@ package org.kie.workbench.common.stunner.core.client.command;
 
 import org.kie.workbench.common.stunner.core.client.canvas.AbstractCanvasHandler;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
-import org.kie.workbench.common.stunner.core.util.UUID;
 
 public abstract class AbstractCanvasCommand implements CanvasCommand<AbstractCanvasHandler> {
 
-    private final transient String uuid;
-
     public AbstractCanvasCommand() {
-        this.uuid = UUID.uuid();
     }
 
     @Override
@@ -35,18 +31,6 @@ public abstract class AbstractCanvasCommand implements CanvasCommand<AbstractCan
 
     protected CommandResult<CanvasViolation> buildResult() {
         return CanvasCommandResultBuilder.SUCCESS;
-    }
-
-    @Override
-    public boolean equals( final Object o ) {
-        if ( this == o ) {
-            return true;
-        }
-        if ( !( o instanceof AbstractCanvasCommand ) ) {
-            return false;
-        }
-        AbstractCanvasCommand that = ( AbstractCanvasCommand ) o;
-        return uuid.equals( that.uuid );
     }
 
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandManagerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasCommandManagerImpl.java
@@ -28,7 +28,6 @@ import org.kie.workbench.common.stunner.core.command.delegate.BatchDelegateComma
 import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 
 import javax.enterprise.event.Event;
-import java.util.Collection;
 
 class CanvasCommandManagerImpl
         extends BatchDelegateCommandManager<AbstractCanvasHandler, CanvasViolation>
@@ -103,7 +102,7 @@ class CanvasCommandManagerImpl
     @Override
     @SuppressWarnings( "unchecked" )
     protected void postExecuteBatch( final AbstractCanvasHandler context,
-                                     final Collection<Command<AbstractCanvasHandler, CanvasViolation>> commands,
+                                     final Iterable<Command<AbstractCanvasHandler, CanvasViolation>> commands,
                                      final BatchCommandResult<CanvasViolation> result ) {
         super.postExecuteBatch( context, commands, result );
         if ( null != result && !CommandUtils.isError( result ) ) {
@@ -143,7 +142,7 @@ class CanvasCommandManagerImpl
     @Override
     @SuppressWarnings( "unchecked" )
     protected void postUndo( final AbstractCanvasHandler context,
-                             final Collection<Command<AbstractCanvasHandler, CanvasViolation>> commands,
+                             final Iterable<Command<AbstractCanvasHandler, CanvasViolation>> commands,
                              final CommandResult<CanvasViolation> result ) {
         super.postUndo( context, commands, result );
         if ( null != result && !CommandUtils.isError( result ) ) {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasStackCommandManager.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/CanvasStackCommandManager.java
@@ -31,7 +31,6 @@ import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
-import java.util.Collection;
 
 @Dependent
 public class CanvasStackCommandManager implements CanvasCommandManager<AbstractCanvasHandler>, StackCommandManager<AbstractCanvasHandler, CanvasViolation> {
@@ -77,7 +76,7 @@ public class CanvasStackCommandManager implements CanvasCommandManager<AbstractC
     }
 
     @Override
-    public Collection<Command<AbstractCanvasHandler, CanvasViolation>> getBatchCommands() {
+    public Iterable<Command<AbstractCanvasHandler, CanvasViolation>> getBatchCommands() {
         return stackCommandManager.getBatchCommands();
     }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/SessionCommandManagerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/command/SessionCommandManagerImpl.java
@@ -33,7 +33,6 @@ import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.Collection;
 import java.util.logging.Logger;
 
 /**
@@ -124,7 +123,7 @@ public class SessionCommandManagerImpl extends BatchDelegateCommandManager<Abstr
     }
 
     @Override
-    public Collection<Command<AbstractCanvasHandler, CanvasViolation>> getBatchCommands() {
+    public Iterable<Command<AbstractCanvasHandler, CanvasViolation>> getBatchCommands() {
         final StackCommandManager<AbstractCanvasHandler, CanvasViolation> scm = ( StackCommandManager<AbstractCanvasHandler, CanvasViolation> ) getBatchDelegate();
         if ( null != scm ) {
             return scm.getBatchCommands();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/session/command/impl/RedoSessionCommand.java
@@ -29,7 +29,6 @@ import org.kie.workbench.common.stunner.core.command.util.RedoCommandHandler;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import java.util.Collection;
 
 import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
 
@@ -80,7 +79,7 @@ public class RedoSessionCommand extends AbstractClientSessionCommand<AbstractCli
     void onCommandUndoExecuted( @Observes CanvasUndoCommandExecutedEvent commandUndoExecutedEvent ) {
         checkNotNull( "commandUndoExecutedEvent", commandUndoExecutedEvent );
         final CanvasCommand<AbstractCanvasHandler> command = ( CanvasCommand<AbstractCanvasHandler> ) commandUndoExecutedEvent.getCommand();
-        final Collection<CanvasCommand<AbstractCanvasHandler>> commands = commandUndoExecutedEvent.getCommands();
+        final Iterable<CanvasCommand<AbstractCanvasHandler>> commands = commandUndoExecutedEvent.getCommands();
         if ( null != command ) {
             redoCommandHandler.onUndoCommandExecuted( command );
         } else {

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/StackCommandManagerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/impl/StackCommandManagerImpl.java
@@ -18,17 +18,15 @@ package org.kie.workbench.common.stunner.core.command.impl;
 
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
-import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.command.HasCommandManagerListener;
 import org.kie.workbench.common.stunner.core.command.batch.BatchCommandManager;
 import org.kie.workbench.common.stunner.core.command.batch.BatchCommandManagerListener;
 import org.kie.workbench.common.stunner.core.command.batch.BatchCommandResult;
 import org.kie.workbench.common.stunner.core.command.stack.StackCommandManager;
+import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.registry.RegistryFactory;
 import org.kie.workbench.common.stunner.core.registry.command.CommandRegistry;
 
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -98,7 +96,7 @@ class StackCommandManagerImpl<C, V> implements StackCommandManager<C, V> {
 
     @Override
     public BatchCommandResult<V> executeBatch( final C context ) {
-        final List<Command<C, V>> batchCommands = new LinkedList<>( batchCommandManager.getBatchCommands() );
+        final List<Command<C, V>> batchCommands = CommandUtils.toList( batchCommandManager.getBatchCommands() );
         LOGGER.log( Level.FINE, "Executing batch commands: " ); logCommands( "--", batchCommands );
         final BatchCommandResult<V> result = batchCommandManager.executeBatch( context );
         if ( null != _listener ) {
@@ -108,15 +106,15 @@ class StackCommandManagerImpl<C, V> implements StackCommandManager<C, V> {
         return result;
     }
 
-    private void logCommands( final String preffix, final Collection<Command<C, V>> commands ) {
+    private void logCommands( final String preffix, final Iterable<Command<C, V>> commands ) {
         if ( null != commands ) {
-            commands.stream().forEach( command ->   LOGGER.log( Level.FINE, preffix + " [" + command + "]" ) );
+            commands.forEach( command ->   LOGGER.log( Level.FINE, preffix + " [" + command + "]" ) );
         }
     }
 
     @Override
     public BatchCommandResult<V> undoBatch( final C context ) {
-        final List<Command<C, V>> batchCommands = new LinkedList<>( batchCommandManager.getBatchCommands() );
+        final Iterable<Command<C, V>> batchCommands = CommandUtils.toList( batchCommandManager.getBatchCommands() );
         LOGGER.log( Level.FINE, "Undoing batch commands: " ); logCommands( "ç--", batchCommands );
         final BatchCommandResult<V> result = batchCommandManager.undoBatch( context );
         if ( null != _listener ) {
@@ -128,7 +126,7 @@ class StackCommandManagerImpl<C, V> implements StackCommandManager<C, V> {
     }
 
     @Override
-    public Collection<Command<C, V>> getBatchCommands() {
+    public Iterable<Command<C, V>> getBatchCommands() {
         return batchCommandManager.getBatchCommands();
     }
 
@@ -177,7 +175,7 @@ class StackCommandManagerImpl<C, V> implements StackCommandManager<C, V> {
 
         @Override
         public void onExecuteBatch( final C context,
-                                    final Collection<Command<C, V>> commands,
+                                    final Iterable<Command<C, V>> commands,
                                     final BatchCommandResult<V> result ) {
             if ( !CommandUtils.isError( result ) ) {
                 // Keep the just executed batched commands on this instance stack.
@@ -195,7 +193,7 @@ class StackCommandManagerImpl<C, V> implements StackCommandManager<C, V> {
 
         @Override
         public void onUndoBatch( final C context,
-                                 final Collection<Command<C, V>> commands,
+                                 final Iterable<Command<C, V>> commands,
                                  final CommandResult<V> result ) {
         }
 

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/GraphCommandManagerImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/graph/command/GraphCommandManagerImpl.java
@@ -26,14 +26,12 @@ import org.kie.workbench.common.stunner.core.command.event.local.CommandUndoExec
 import org.kie.workbench.common.stunner.core.command.event.local.IsCommandAllowedEvent;
 import org.kie.workbench.common.stunner.core.command.exception.CommandException;
 import org.kie.workbench.common.stunner.core.command.impl.BatchCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.command.impl.BatchCommandResultImpl;
+import org.kie.workbench.common.stunner.core.command.util.CommandUtils;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -115,7 +113,7 @@ public class GraphCommandManagerImpl
     }
 
     @Override
-    public Collection<Command<GraphCommandExecutionContext, RuleViolation>> getBatchCommands() {
+    public Iterable<Command<GraphCommandExecutionContext, RuleViolation>> getBatchCommands() {
         return batchCommandManager.getBatchCommands();
     }
 
@@ -135,7 +133,7 @@ public class GraphCommandManagerImpl
         final BatchCommandResult<RuleViolation> result = batchCommandManager.undoBatch( context );
         if ( null != commandUndoExecutedEvent ) {
             final CommandUndoExecutedEvent event = new CommandUndoExecutedEvent(
-                    new ArrayList<>( batchCommandManager.getBatchCommands() ),
+                    CommandUtils.toList( batchCommandManager.getBatchCommands() ),
                     result );
             commandUndoExecutedEvent.fire( event );
         }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/CommandRegistryImpl.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/registry/impl/CommandRegistryImpl.java
@@ -25,7 +25,9 @@ import java.util.Collection;
 import java.util.Deque;
 
 /**
- * The Stack class behavior when using the iterator is not the expected one, so used
+ * The default generic implementation for the CommandRegistry type.
+ * It's implemented for achieving an in-memory and lightweight registry approach, don't do an overuse of it.
+ * Note: The Stack class behavior when using the iterator is not the expected one, so used
  * ArrayDeque instead of an Stack to provide right iteration order.
  */
 public class CommandRegistryImpl<C extends Command> implements CommandRegistry<C> {
@@ -39,7 +41,7 @@ public class CommandRegistryImpl<C extends Command> implements CommandRegistry<C
     }
 
     @Override
-    public void register( final Collection<C> commands ) {
+    public void register( final Iterable<C> commands ) {
         addIntoStack( commands );
     }
 
@@ -99,15 +101,19 @@ public class CommandRegistryImpl<C extends Command> implements CommandRegistry<C
         }
     }
 
-    private void addIntoStack( final Collection<C> _commands ) {
-        if ( null != _commands && !_commands.isEmpty() ) {
-            if ( ( commands.size() + _commands.size() ) > maxStackSize ) {
+    private void addIntoStack( final Iterable<C> _commands ) {
+        final int[] cs = { commands.size() };
+        final Deque<C> s = new ArrayDeque<>();
+        _commands.forEach( ( e ) -> {
+            s.push( e );
+            if ( cs[0] + 1 > maxStackSize ) {
                 stackSizeExceeded();
+            } else {
+                cs[ 0 ]++;
+
             }
-            final Deque<C> s = new ArrayDeque<>();
-            _commands.forEach( s::push );
-            commands.push( s );
-        }
+        } );
+        commands.push( s );
     }
 
     private void stackSizeExceeded() {


### PR DESCRIPTION
Hey @csadilek , 
As commented before, here are some fixes for the commands stuff. Finally I replaced the use of Collections everywhere, that in fact should be Lists in order to guarantee order, by the use of Iterables on the different public methods, I think it's the most generic we can do. 
So each implementation ( whatever it's a command registry or it's a command mamanger ), have to guarantee that the iteration order for the commands is the expected one ( internally they can use whatever implmentation to handle the collection such as list stacks etc, only need to guarantee order on public api - I have added javadocs about this as well ). 
Please can you verify this and lemme know your thoughts? Thanks in adavance!!