### PR TITLE
Include 'zh_CN' locale in Replacer Plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
             <include>**/*_fr.properties</include>
             <include>**/*_ja.properties</include>
             <include>**/*_pt_BR.properties</include>
+            <include>**/*_zh_CN.properties</include>
           </includes>
           <excludes>
             <exclude>**/ErraiApp.properties</exclude>


### PR DESCRIPTION
@mbiarnes Hi.. this should fix https://github.com/droolsjbpm/kie-wb-common/pull/554

I'd suggest closing https://github.com/droolsjbpm/kie-wb-common/pull/554, running the i18n again for ```kie-wb-common``` and submitting a new PR.