### PR TITLE
[6.5.x] Include 'zh_CN' locale in Replacer Plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
             <include>**/*_fr.properties</include>
             <include>**/*_ja.properties</include>
             <include>**/*_pt_BR.properties</include>
+            <include>**/*_zh_CN.properties</include>
           </includes>
           <excludes>
             <exclude>**/ErraiApp.properties</exclude>


### PR DESCRIPTION
This is the corollary of https://github.com/droolsjbpm/kie-wb-common/pull/555 for 6.5.x

(cherry picked from commit 8f7c1d49d1873c914e34cab44e91fb5f010fa4bf)