### PR TITLE
RHBRMS-2689: Unable to build project if kbase and ksession names are identical

### DIFF
--- a/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/kmodule/converters/KModuleConverter.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/main/java/org/kie/workbench/common/services/backend/kmodule/converters/KModuleConverter.java
@@ -34,7 +34,8 @@ public class KModuleConverter
     public void marshal(Object value, HierarchicalStreamWriter writer, MarshallingContext context) {
         KModuleModel kModule = (KModuleModel) value;
 
-        writer.addAttribute("xmlns", "http://jboss.org/kie/6.0.0/kmodule");
+        //https://issues.jboss.org/browse/DROOLS-1023 introduced "version-less" XSDs
+        writer.addAttribute("xmlns", "http://www.drools.org/xsd/kmodule");
         writer.addAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
 
         for (KBaseModel kBaseModule : kModule.getKBases().values()) {

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/kmodule/KModuleContentHandlerTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/kmodule/KModuleContentHandlerTest.java
@@ -18,10 +18,10 @@ package org.kie.workbench.common.services.backend.kmodule;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;import java.lang.Exception;import java.lang.IllegalStateException;import java.lang.String;import java.lang.StringBuffer;
+import java.io.InputStreamReader;
 
-import org.kie.workbench.common.services.shared.kmodule.KModuleModel;
 import org.junit.Test;
+import org.kie.workbench.common.services.shared.kmodule.KModuleModel;
 
 import static org.junit.Assert.*;
 
@@ -34,6 +34,15 @@ public class KModuleContentHandlerTest {
         KModuleModel model = kModuleContentHandler.toModel(readResource("simpleKModule.xml"));
 
         assertNotNull(model);
+    }
+
+    @Test
+    public void testMarshallingOfDefaultDroolsNameSpace() throws Exception {
+        final KModuleContentHandler kModuleContentHandler = new KModuleContentHandler();
+        final String kmodule = kModuleContentHandler.toString( new KModuleModel() );
+
+        assertNotNull( kmodule );
+        assertTrue( kmodule.contains( "xmlns=\"http://www.drools.org/xsd/kmodule\"" ) );
     }
 
     private String readResource(String name) {


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2689

See also https://github.com/droolsjbpm/drools/pull/1004 and https://github.com/droolsjbpm/droolsjbpm-knowledge/pull/187

The Workbench also needs to use the "version-less" Name Space (for new Projects). Older Projects created in the Workbench are tied to 6.0.0 XSD and hence, if the fix for RHBRMS-2689 is needed in older versions, the old 6.0.0 XSD would need updating too :-(

See https://issues.jboss.org/browse/DROOLS-1023