### PR TITLE
JBPM-5233: Data source management

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-backend/src/test/java/org/kie/workbench/common/screens/datasource/management/backend/core/DataSourceManagementTestConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-backend/src/test/java/org/kie/workbench/common/screens/datasource/management/backend/core/DataSourceManagementTestConstants.java
@@ -18,6 +18,8 @@ package org.kie.workbench.common.screens.datasource.management.backend.core;
 
 public interface DataSourceManagementTestConstants {
 
+    String SEPARATOR = "#";
+
     String RANDOM_UUID = "random_uuid";
 
     String DS1_UUID = "uuid1";
@@ -32,7 +34,7 @@ public interface DataSourceManagementTestConstants {
 
     String DS1_JNID = "jndi1";
 
-    String DS1_DEPLOYMENT_ID = "kie:" + DS1_UUID + ":_" + RANDOM_UUID;
+    String DS1_DEPLOYMENT_ID = "kie" + SEPARATOR + DS1_UUID + SEPARATOR + "_" + RANDOM_UUID;
 
     String DS2_UUID = "uuid2";
 
@@ -46,15 +48,15 @@ public interface DataSourceManagementTestConstants {
 
     String DS2_JNID = "jndi2";
 
-    String DS2_DEPLOYMENT_ID = "kie:" + DS2_UUID + ":_" + RANDOM_UUID;
+    String DS2_DEPLOYMENT_ID = "kie" + SEPARATOR + DS2_UUID + SEPARATOR + "_" + RANDOM_UUID;
 
     String DS3_UUID = "uuid3";
 
-    String DS3_DEPLOYMENT_ID = "kie:" + DS3_UUID + ":_" + RANDOM_UUID;
+    String DS3_DEPLOYMENT_ID = "kie" + SEPARATOR + DS3_UUID + SEPARATOR + "_" + RANDOM_UUID;
 
     String DRIVER1_UUID = "driverUuid1";
 
-    String DRIVER1_DEPLOYMENT_ID = "kie:" + DRIVER1_UUID + ":";
+    String DRIVER1_DEPLOYMENT_ID = "kie" + SEPARATOR + DRIVER1_UUID + SEPARATOR;
 
     String DRIVER1_NAME = "driver1";
 

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/main/java/org/kie/workbench/common/screens/datasource/management/backend/core/wildfly/DeploymentIdGenerator.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/main/java/org/kie/workbench/common/screens/datasource/management/backend/core/wildfly/DeploymentIdGenerator.java
@@ -28,20 +28,20 @@ import org.kie.workbench.common.screens.datasource.management.model.DriverDef;
  */
 public class DeploymentIdGenerator {
 
-    private static final String SEPARATOR = ":";
+    private static final String SEPARATOR = "#";
 
-    private static final Pattern KIE_GENERATED_ID = Pattern.compile( "kie:([^:]+):(.*)" );
+    private static final Pattern KIE_GENERATED_ID = Pattern.compile( "kie#([^#]+)#(.*)" );
 
-    private static final Pattern KIE_ID = Pattern.compile( "kie:([^:]+):" );
+    private static final Pattern KIE_ID = Pattern.compile( "kie#([^#]+)#" );
 
     public static String extractUuid( final String deploymentId ) throws Exception {
-        //deployments created by the kie-wb typically has the from "kie:uuid:XXXX", where could XXXX be a string added
+        //deployments created by the kie-wb typically has the from "kie#uuid#XXXX", where could XXXX be a string added
         // by the wildfly server and that we can't manage. For example for the driver deployments.
 
         if ( deploymentId != null && isKieGenerated( deploymentId ) ) {
             Matcher matcher = KIE_ID.matcher( deploymentId );
             if ( matcher.find() ) {
-                String[] parts = matcher.group().split( ":" );
+                String[] parts = matcher.group().split( SEPARATOR );
                 if ( parts.length > 1 ) {
                     return parts[1];
                 }

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/test/java/org/kie/workbench/common/screens/datasource/management/backend/core/wildfly/DeploymentIdGeneratorTest.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/test/java/org/kie/workbench/common/screens/datasource/management/backend/core/wildfly/DeploymentIdGeneratorTest.java
@@ -43,7 +43,7 @@ public class DeploymentIdGeneratorTest {
     @Test
     public void testExtractUuid() {
         try {
-            assertEquals( "abc", DeploymentIdGenerator.extractUuid( "kie:abc:" ) );
+            assertEquals( "abc", DeploymentIdGenerator.extractUuid( "kie#abc#" ) );
         } catch ( Exception e ) {
             fail( e.getMessage() );
         }
@@ -52,7 +52,7 @@ public class DeploymentIdGeneratorTest {
     @Test
     public void testExtractInvalidUuid( ) {
         //all this are invalid deployment ids, so the extraction should fail for all of them.
-        String invalidValues[] = { "abc", "kie:", "kie::" };
+        String invalidValues[] = { "abc", "kie#", "kie##" };
         for ( int i = 0; i < invalidValues.length; i++ ) {
             testExtractUuidInvalidUuid( invalidValues[ i ] );
         }
@@ -63,9 +63,9 @@ public class DeploymentIdGeneratorTest {
         when ( driverDef.getUuid() ).thenReturn( "driver1" );
         when( dataSourceDef.getUuid() ).thenReturn( "dataSource1" );
 
-        assertEquals( "kie:driver1:", DeploymentIdGenerator.generateDeploymentId( driverDef ) );
-        assertEquals( "kie:dataSource1:", DeploymentIdGenerator.generateDeploymentId( dataSourceDef ) );
-        assertEquals( "kie:someValue:", DeploymentIdGenerator.generateDeploymentId( "someValue" ) );
+        assertEquals( "kie#driver1#", DeploymentIdGenerator.generateDeploymentId( driverDef ) );
+        assertEquals( "kie#dataSource1#", DeploymentIdGenerator.generateDeploymentId( dataSourceDef ) );
+        assertEquals( "kie#someValue#", DeploymentIdGenerator.generateDeploymentId( "someValue" ) );
     }
 
     private void testExtractUuidInvalidUuid( String invalidUuid ) {

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/test/java/org/kie/workbench/common/screens/datasource/management/backend/core/wildfly/WildflyDriverProviderTest.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-wildfly/src/test/java/org/kie/workbench/common/screens/datasource/management/backend/core/wildfly/WildflyDriverProviderTest.java
@@ -37,9 +37,9 @@ import static org.mockito.Mockito.*;
 public class WildflyDriverProviderTest
         extends DriverProviderBaseTest {
 
-    private static final String DRIVER1_DEPLOYMENT_ID = "kie:" + DRIVER1_UUID + ":";
+    private static final String DRIVER1_DEPLOYMENT_ID = "kie#" + DRIVER1_UUID + "#";
 
-    private static final String UUID2_DEPLOYMENT_ID = "kie:" + DRIVER2_UUID + ":";
+    private static final String UUID2_DEPLOYMENT_ID = "kie#" + DRIVER2_UUID + "#";
 
     @Mock
     private WildflyDriverManagementClient managementClient;


### PR DESCRIPTION
    - changes the deployment id separator to avoid WF conflicts in windows systems