### PR TITLE
[DROOLS-1391] no need to depend on gwt-user 

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-backend/pom.xml
@@ -221,11 +221,6 @@
       <artifactId>jboss-ejb-api_3.2_spec</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-user</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>


### PR DESCRIPTION
We just need the annotations to satisfy WELD. No need to drag in
the whole gwt-user jar (which bundles the annotations as well).

Depends on https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/347