### PR TITLE
GUVNOR-2831: [Guided Decision Table] Two BRL Condition fragments throws Indexing Exception

### DIFF
--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/ResourceReference.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-api/src/main/java/org/kie/workbench/common/services/refactoring/model/index/ResourceReference.java
@@ -34,7 +34,8 @@ public class ResourceReference implements IndexElementsGenerator {
     private final ResourceType resourceType; // this might be (initially?) unknown
     private Map<String, ValuePartReferenceIndexTerm> fieldNamepartReferenceMap;
 
-    public ResourceReference( final String resourceFQN, ResourceType resoureType ) {
+    public ResourceReference( final String resourceFQN,
+                              ResourceType resoureType ) {
         this.resourceFQN = PortablePreconditions.checkNotNull( "resourceFQN", resourceFQN );
         this.resourceType = PortablePreconditions.checkNotNull( "resourceType", resoureType );
     }
@@ -43,19 +44,25 @@ public class ResourceReference implements IndexElementsGenerator {
         return this.resourceType;
     }
 
-    public void addPartReference(String partName, PartType partType) {
-        if( fieldNamepartReferenceMap == null ) {
-            this.fieldNamepartReferenceMap = new HashMap<String, ValuePartReferenceIndexTerm>(4);
+    public void addPartReference( String partName,
+                                  PartType partType ) {
+        if ( fieldNamepartReferenceMap == null ) {
+            this.fieldNamepartReferenceMap = new HashMap<String, ValuePartReferenceIndexTerm>( 4 );
         }
-        fieldNamepartReferenceMap.put(partName, new ValuePartReferenceIndexTerm(resourceFQN, partName, partType));
+        fieldNamepartReferenceMap.put( partName, new ValuePartReferenceIndexTerm( resourceFQN, partName, partType ) );
     }
 
-    public void addPartReference(Map<String, ValuePartReferenceIndexTerm> partReferences) {
-        fieldNamepartReferenceMap.putAll(partReferences);
+    public void addPartReference( Map<String, ValuePartReferenceIndexTerm> partReferences ) {
+        if ( !( partReferences == null || partReferences.isEmpty() ) ) {
+            if ( fieldNamepartReferenceMap == null ) {
+                this.fieldNamepartReferenceMap = new HashMap<>( 4 );
+            }
+            fieldNamepartReferenceMap.putAll( partReferences );
+        }
     }
 
     public Map<String, ValuePartReferenceIndexTerm> getPartReferences() {
-        if( fieldNamepartReferenceMap == null ) {
+        if ( fieldNamepartReferenceMap == null ) {
             return Collections.emptyMap();
         }
         return fieldNamepartReferenceMap;
@@ -66,14 +73,14 @@ public class ResourceReference implements IndexElementsGenerator {
         final List<Pair<String, String>> indexElements = new ArrayList<Pair<String, String>>();
 
         // Impact Analysis references
-        if( resourceFQN != null ) {
-            ValueReferenceIndexTerm refTerm = new ValueReferenceIndexTerm(this.resourceFQN, this.resourceType);
-            indexElements.add(new Pair<String, String>(refTerm.getTerm(), refTerm.getValue()));
+        if ( resourceFQN != null ) {
+            ValueReferenceIndexTerm refTerm = new ValueReferenceIndexTerm( this.resourceFQN, this.resourceType );
+            indexElements.add( new Pair<String, String>( refTerm.getTerm(), refTerm.getValue() ) );
         }
 
-        if( this.fieldNamepartReferenceMap != null ) {
-            for( ValuePartReferenceIndexTerm refPartTerm : fieldNamepartReferenceMap.values() ) {
-                indexElements.add(new Pair<String, String>(refPartTerm.getTerm(), refPartTerm.getValue()));
+        if ( this.fieldNamepartReferenceMap != null ) {
+            for ( ValuePartReferenceIndexTerm refPartTerm : fieldNamepartReferenceMap.values() ) {
+                indexElements.add( new Pair<String, String>( refPartTerm.getTerm(), refPartTerm.getValue() ) );
             }
         }
 

--- a/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/impact/ResourceReferenceCollectorTest.java
+++ b/kie-wb-common-services/kie-wb-common-refactoring/kie-wb-common-refactoring-backend/src/test/java/org/kie/workbench/common/services/refactoring/backend/server/impact/ResourceReferenceCollectorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.workbench.common.services.refactoring.backend.server.impact;
+
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.workbench.common.services.refactoring.model.index.ResourceReference;
+import org.kie.workbench.common.services.refactoring.service.ResourceType;
+
+import static org.junit.Assert.*;
+
+public class ResourceReferenceCollectorTest {
+
+    private class TestResourceReferenceCollector extends ResourceReferenceCollector {
+
+    }
+
+    private TestResourceReferenceCollector collector;
+
+    @Before
+    public void setup() {
+        collector = new TestResourceReferenceCollector();
+    }
+
+    @Test
+    public void checkAddResourceReference() {
+        whenCollectorHasResourceReference( collector,
+                                           "f.q.c.n",
+                                           ResourceType.JAVA );
+
+        thenCollectorHasResourceReferences( collector,
+                                            1 );
+        thenResourceReferenceHasPartReferences( collector.getResourceReferences().stream().findFirst().get(),
+                                                0 );
+    }
+
+    @Test
+    public void checkAddResourceReferences() {
+        final TestResourceReferenceCollector siblingCollector = new TestResourceReferenceCollector();
+
+        whenCollectorHasResourceReference( collector,
+                                           "f.q.c.n",
+                                           ResourceType.JAVA );
+        whenCollectorHasResourceReference( siblingCollector,
+                                           "f.q.c.n",
+                                           ResourceType.JAVA );
+        whenCollectorHasSiblingCollectorsResourceReference( collector,
+                                                            siblingCollector );
+
+        thenCollectorHasResourceReferences( siblingCollector,
+                                            1 );
+        thenResourceReferenceHasPartReferences( siblingCollector.getResourceReferences().stream().findFirst().get(),
+                                                0 );
+    }
+
+    private void whenCollectorHasResourceReference( final ResourceReferenceCollector collector,
+                                                    final String fqcn,
+                                                    final ResourceType type ) {
+        collector.addResourceReference( fqcn,
+                                        type );
+    }
+
+    private void whenCollectorHasSiblingCollectorsResourceReference( final ResourceReferenceCollector collector,
+                                                                     final ResourceReferenceCollector sibling ) {
+        collector.addResourceReferences( sibling );
+    }
+
+    private void thenCollectorHasResourceReferences( final ResourceReferenceCollector collector,
+                                                     final int resourceReferencesCount ) {
+        final Collection<ResourceReference> resourceReferences = collector.getResourceReferences();
+        assertNotNull( resourceReferences );
+        assertEquals( resourceReferencesCount,
+                      resourceReferences.size() );
+    }
+
+    private void thenResourceReferenceHasPartReferences( final ResourceReference resourceReference,
+                                                         final int partReferencesCount ) {
+        assertNotNull( resourceReference );
+        assertEquals( ResourceType.JAVA,
+                      resourceReference.getResourceType() );
+        assertEquals(
+                partReferencesCount,
+                resourceReference.getPartReferences().size() );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2831

Method ```addPartReference( Map )``` assumes method ```addPartReference( String, PartType )``` has been called to initialise the internal map instance. You know what is said about assuming things.. 