### PR TITLE
JBPM-5609: Stunner - fix BpmnFileIndexerTest failure by increasing wa…

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/indexing/BpmnFileIndexerTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/src/test/java/org/kie/workbench/common/stunner/bpmn/backend/service/indexing/BpmnFileIndexerTest.java
@@ -107,7 +107,7 @@ public class BpmnFileIndexerTest extends BaseIndexingTest<BPMNDefinitionSetResou
         }
         Path[] paths = pathList.toArray(new Path[pathList.size()]);
 
-        Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep(15000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
         {
             final RefactoringPageRequest request = new RefactoringPageRequest(FindResourcesQuery.NAME,


### PR DESCRIPTION
…it for indexing to finish.

This test was passing locally but failed on Jenkins. I can get the test to fail locally with the same error as reported on Jenkins by reducing the wait time, so I think increasing the wait time should fix the test on Jenkins.

See https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/kie-releases-7.0.x/job/031.Releasing_KIE_deployLocally-7.0.x/lastCompletedBuild/testReport/ 