### PR TITLE
RHBPMS-4604: Fix DataModelServiceConstructorTest

### DIFF
--- a/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/DataModelServiceConstructorTest.java
+++ b/kie-wb-common-services/kie-wb-common-datamodel/kie-wb-common-datamodel-backend/src/test/java/org/kie/workbench/common/services/datamodel/backend/server/DataModelServiceConstructorTest.java
@@ -82,6 +82,7 @@ import org.kie.workbench.common.services.datamodel.backend.server.cache.LRUProje
 import org.kie.workbench.common.services.datamodel.backend.server.cache.ProjectDataModelOracleBuilderProvider;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.kie.workbench.common.services.shared.dependencies.DependencyService;
+import org.kie.workbench.common.services.shared.project.KieProject;
 import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.kie.workbench.common.services.shared.project.ProjectImportsService;
 import org.kie.workbench.common.services.shared.whitelist.PackageNameWhiteListService;
@@ -183,6 +184,7 @@ public class DataModelServiceConstructorTest {
     @Test
     public void testConstructor()
             throws IllegalArgumentException, FileSystemNotFoundException, SecurityException, URISyntaxException {
+
         final URL packageUrl = this.getClass().getResource("/DataModelServiceConstructorTest/src/main/java/t1p1");
 
         IOService ioService = new IOServiceDotFileImpl();
@@ -267,7 +269,12 @@ public class DataModelServiceConstructorTest {
                                                                        configurationService,
                                                                        commentedOptionFactory,
                                                                        backward,
-                                                                       kModuleService);
+                                                                       kModuleService) {
+            @Override
+            protected void addSecurityGroups(final KieProject project) {
+                //Do nothing. This test demonstrating DMO usage without WELD does not use permissions.
+            }
+        };
         ProjectSaver projectSaver = null;
         projectService = new HackedKieProjectServiceImpl(ioService,
                                                          projectSaver,


### PR DESCRIPTION
Further to https://github.com/droolsjbpm/kie-wb-common/pull/658

```droolsjbpm/master@kie-wb-common``` is failing in our CI environment at the moment.

```KieResourceResolver``` attempts to store Projects' permissions in ```system.git```. This fix simply overrides ```KieResourceResolver.addSecurityGroups()``` to avoid use of ```system.git```. The test demonstrates use of DMO outside a WELD evironment (for use with the Eclipse tooling integration by @bbrodt )
