### PR TITLE
Stunner - Added findbugs maven plugin execution

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/ActionsToolboxControlProvider.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-client-common/src/main/java/org/kie/workbench/common/stunner/core/client/canvas/controls/toolbox/ActionsToolboxControlProvider.java
@@ -58,9 +58,9 @@ public class ActionsToolboxControlProvider extends AbstractToolboxControlProvide
     public ActionsToolboxControlProvider(final ToolboxFactory toolboxFactory,
                                          final ToolboxCommandFactory toolboxCommandFactory) {
         super(toolboxFactory);
-        this.removeToolboxCommand = toolboxCommandFactory.newRemoveToolboxCommand();
-        this.moveShapeUpToolboxCommand = toolboxCommandFactory.newMoveShapeUpToolboxCommand();
-        this.moveShapeDownToolboxCommand = toolboxCommandFactory.newMoveShapeDownToolboxCommand();
+        this.removeToolboxCommand = null != toolboxCommandFactory ? toolboxCommandFactory.newRemoveToolboxCommand() : null;
+        this.moveShapeUpToolboxCommand = null != toolboxCommandFactory ? toolboxCommandFactory.newMoveShapeUpToolboxCommand() : null;
+        this.moveShapeDownToolboxCommand = null != toolboxCommandFactory ? toolboxCommandFactory.newMoveShapeDownToolboxCommand() : null;
     }
 
     @Override

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/main/java/org/kie/workbench/common/stunner/core/command/util/RedoCommandHandler.java
@@ -54,7 +54,7 @@ public class RedoCommandHandler<C extends Command> {
 
     @Inject
     public RedoCommandHandler(final RegistryFactory registryFactory) {
-        this.registry = registryFactory.newCommandRegistry();
+        this.registry = null != registryFactory ? registryFactory.newCommandRegistry() : null;
     }
 
     public boolean onUndoCommandExecuted(final C command) {

--- a/kie-wb-common-stunner/pom.xml
+++ b/kie-wb-common-stunner/pom.xml
@@ -139,6 +139,25 @@
           </executions>
         </plugin>
 
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <configuration>
+            <maxRank>6</maxRank>
+            <effort>Max</effort>
+            <xmlOutput>true</xmlOutput>
+          </configuration>
+          <executions>
+            <execution>
+              <id>findbugs-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>compile</phase>
+            </execution>
+          </executions>
+        </plugin>
+ 
       </plugins>
 
     </pluginManagement>
@@ -204,6 +223,21 @@
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
 
+      <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.1.10</version>
+        <configuration>
+          <timestampedReports>false</timestampedReports>
+          <targetClasses>
+            <param>org.kie.workbench.common.stunner.*</param>
+          </targetClasses>
+          <targetTests>
+            <param>org.kie.workbench.common.stunner.*</param>
+          </targetTests>
+        </configuration>
+      </plugin>
+
     </plugins>
 
   </build>
@@ -216,6 +250,14 @@
           <name>full</name>
         </property>
       </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Hey @hasys ,
Here it is the initial version you proposed for the findbugs maven plugin running on Stunner, when using the `full` profile as already discussed. Not sure if this finally have to be merged or it's still not decided, due latest discussions on our bsig mailing list... 
Anyway it's now configured with `maxRank=6`, so just a few failures were raised, and fixed, but that's an initial point :)