### PR TITLE
fix Windows specific test failures

### DIFF
--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/codegen/GenerationEngineTest.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/codegen/GenerationEngineTest.java
@@ -16,11 +16,25 @@
 
 package org.kie.workbench.common.services.datamodeller.codegen;
 
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-
-import org.kie.workbench.common.services.datamodeller.core.*;
+import org.kie.workbench.common.services.datamodeller.core.Annotation;
+import org.kie.workbench.common.services.datamodeller.core.AnnotationDefinition;
+import org.kie.workbench.common.services.datamodeller.core.DataModel;
+import org.kie.workbench.common.services.datamodeller.core.DataObject;
+import org.kie.workbench.common.services.datamodeller.core.Method;
+import org.kie.workbench.common.services.datamodeller.core.ObjectProperty;
+import org.kie.workbench.common.services.datamodeller.core.Parameter;
+import org.kie.workbench.common.services.datamodeller.core.Type;
+import org.kie.workbench.common.services.datamodeller.core.Visibility;
 import org.kie.workbench.common.services.datamodeller.core.impl.AnnotationImpl;
 import org.kie.workbench.common.services.datamodeller.core.impl.MethodImpl;
 import org.kie.workbench.common.services.datamodeller.core.impl.ObjectPropertyImpl;
@@ -30,12 +44,7 @@ import org.kie.workbench.common.services.datamodeller.driver.impl.DataModelOracl
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import static org.junit.Assert.*;
 
 public class GenerationEngineTest {
 
@@ -53,6 +62,13 @@ public class GenerationEngineTest {
             InputStream in = this.getClass().getResourceAsStream( "GenerationTestResults.properties" );
             results.load(in);
             in.close();
+            Set<String> propertyNames = results.stringPropertyNames();
+            for (String property : propertyNames) {
+                String newProperty = results.getProperty(property).replaceAll("\n",
+                                                                              System.getProperty("line.separator"));
+                results.setProperty(property,
+                                    newProperty);
+            }
 
             engine = GenerationEngine.getInstance();
             dataModelOracleDriver = DataModelOracleModelDriver.getInstance();

--- a/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/parser/JavaFileHandler1Test.java
+++ b/kie-wb-common-services/kie-wb-common-data-modeller-core/src/test/java/org/kie/workbench/common/services/datamodeller/parser/JavaFileHandler1Test.java
@@ -16,14 +16,17 @@
 
 package org.kie.workbench.common.services.datamodeller.parser;
 
-import org.junit.Test;
-import org.kie.workbench.common.services.datamodeller.parser.descr.*;
-import org.kie.workbench.common.services.datamodeller.parser.util.ParserUtil;
-
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+import org.kie.workbench.common.services.datamodeller.parser.descr.ClassDescr;
+import org.kie.workbench.common.services.datamodeller.parser.descr.DescriptorFactoryImpl;
+import org.kie.workbench.common.services.datamodeller.parser.descr.FieldDescr;
+import org.kie.workbench.common.services.datamodeller.parser.descr.MethodDescr;
+import org.kie.workbench.common.services.datamodeller.parser.descr.TextTokenElementDescr;
+import org.kie.workbench.common.services.datamodeller.parser.util.ParserUtil;
+
+import static org.junit.Assert.*;
 
 public class JavaFileHandler1Test extends JavaFileHandlerBaseTest {
 
@@ -74,7 +77,8 @@ public class JavaFileHandler1Test extends JavaFileHandlerBaseTest {
             assertEquals( fileContents[ 3 ], fileHandler.buildResult( ) );
 
             fieldDescr = DescriptorFactoryImpl.getInstance( ).createFieldDescr( "public int field100 = 12;" );
-            StringBuilder indentStr = new StringBuilder( "\n\n    " );
+            StringBuilder indentStr = new StringBuilder(System.getProperty("line.separator") +
+                                                                System.getProperty("line.separator") + "    ");
             TextTokenElementDescr indent = new TextTokenElementDescr( "", 0, indentStr.length( ) - 1, 1, 0 );
             indent.setSourceBuffer( indentStr );
 


### PR DESCRIPTION
When we run community tests against productized binaries on Windows, there are some Windows specific test failures. Most of these failures are caused by line separators and file paths. There will be some more fixes also in other repositories. 
This commit contains some minor changes in tests that replace \n separator by the OS specific separator.