### PR TITLE
Stunner - jacoco plugin configurations to notify about decreased test coverage

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-backend/pom.xml
@@ -30,6 +30,10 @@
   <description>Kie Workbench - Common - Stunner - Backend</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.0</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
@@ -30,6 +30,10 @@
   <description>Kie Workbench - Common - Stunner - Client Widgets</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.0</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <!-- Stunner. -->

--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/pom.xml
@@ -30,6 +30,10 @@
   <description>Kie Workbench - Common - Stunner - Commons</description>
   <packaging>pom</packaging>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.1</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <modules>
     <module>kie-wb-common-stunner-core-common</module>
     <module>kie-wb-common-stunner-backend-common</module>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-forms/kie-wb-common-stunner-forms-client/pom.xml
@@ -29,6 +29,10 @@
   <name>Kie Workbench - Common - Stunner - Forms Client</name>
   <description>Kie Workbench - Common - Stunner - Forms Client</description>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.2</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-lienzo-extensions/pom.xml
@@ -30,6 +30,10 @@
   <description>Kie Workbench - Common - Stunner - Lienzo Extensions</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.0</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <!-- GWT. -->

--- a/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-extensions/kie-wb-common-stunner-project/kie-wb-common-stunner-project-client/pom.xml
@@ -29,6 +29,10 @@
   <name>Kie Workbench - Common - Stunner - Project integration Client</name>
   <description>Kie Workbench - Common - Stunner - Project integration Client</description>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.0</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <!-- Stunner deps. -->

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/pom.xml
@@ -30,6 +30,10 @@
   <description>Kie Workbench - Common - Stunner - BPMN Definition Set - API</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.0</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-backend/pom.xml
@@ -30,6 +30,10 @@
   <description>Kie Workbench - Common - Stunner - BPMN Definition Set - Backend</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.4</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-client/pom.xml
@@ -30,6 +30,10 @@
   <description>Kie Workbench - Common - Stunner - BPMN Definition Set - Client</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <jacoco.line.coveredratio.minimum>0.4</jacoco.line.coveredratio.minimum>
+  </properties>
+
   <dependencies>
 
     <!-- Stunner. -->

--- a/kie-wb-common-stunner/pom.xml
+++ b/kie-wb-common-stunner/pom.xml
@@ -43,6 +43,7 @@
 
   <properties>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
+    <jacoco.haltOnFailure>true</jacoco.haltOnFailure>
   </properties>
 
   <build>


### PR DESCRIPTION
With this changes it is possible to check is new PR decreases test coverage of Stunner.

To run jacoco plugin run [1] on project root. If test-coverage were decreases it will fail (only profile [1], regular build will be successful). If test-coverage didn't decreased you can found test-coverage reports in target/site/jacoco (for project with any tests).
[1]
```
mvn clean verify -Dcode-coverage
```

Known issue:
Tests with mock are not counting due to conflicts between current Jacoco and mock versions. This issue in progress.