### PR TITLE
Stunner - revise core.command.impl classes test coverage

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/impl/CompositeCommandTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-commons/kie-wb-common-stunner-core-common/src/test/java/org/kie/workbench/common/stunner/core/command/impl/CompositeCommandTest.java
@@ -22,8 +22,6 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.stunner.core.command.Command;
 import org.kie.workbench.common.stunner.core.command.CommandResult;
 import org.kie.workbench.common.stunner.core.graph.command.GraphCommandExecutionContext;
-import org.kie.workbench.common.stunner.core.graph.command.GraphCommandResultBuilder;
-import org.kie.workbench.common.stunner.core.graph.command.impl.AbstractGraphCommand;
 import org.kie.workbench.common.stunner.core.rule.RuleViolation;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -37,11 +35,11 @@ public class CompositeCommandTest {
 
     @Mock
     GraphCommandExecutionContext commandExecutionContext;
-    private CompositeCommandStub tested;
+    private CompositeCommandImpl tested;
 
     @Before
     public void setup() throws Exception {
-        this.tested = spy(new CompositeCommandStub());
+        this.tested = spy(new CompositeCommandImpl<>(true));
     }
 
     @Test
@@ -59,8 +57,9 @@ public class CompositeCommandTest {
         assertNotNull(result);
         assertEquals(CommandResult.Type.INFO,
                      result.getType());
-        verify(tested,
-               times(1)).addCommand(any(CommandStub.class));
+
+        //fails here
+        verify(tested).addCommand(any(Command.class));
     }
 
     @Test
@@ -70,64 +69,8 @@ public class CompositeCommandTest {
         assertNotNull(result);
         assertEquals(CommandResult.Type.INFO,
                      result.getType());
-        verify(tested,
-               times(1)).addCommand(any(CommandStub.class));
-    }
 
-    private static class CompositeCommandStub extends AbstractCompositeCommand<GraphCommandExecutionContext, RuleViolation> {
-
-        @Override
-        protected CompositeCommandStub initialize(GraphCommandExecutionContext context) {
-            super.initialize(context);
-            addCommand(new CommandStub());
-            return this;
-        }
-
-        @Override
-        protected CommandResult<RuleViolation> doAllow(GraphCommandExecutionContext context,
-                                                       Command<GraphCommandExecutionContext, RuleViolation> command) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        protected CommandResult<RuleViolation> doExecute(GraphCommandExecutionContext context,
-                                                         Command<GraphCommandExecutionContext, RuleViolation> command) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        protected CommandResult<RuleViolation> doUndo(GraphCommandExecutionContext context,
-                                                      Command<GraphCommandExecutionContext, RuleViolation> command) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        public CommandResult<RuleViolation> undo(final GraphCommandExecutionContext context) {
-            return super.undo(context,
-                              true);
-        }
-    }
-
-    private static class CommandStub extends AbstractGraphCommand {
-
-        @Override
-        protected CommandResult<RuleViolation> check(GraphCommandExecutionContext context) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        public CommandResult<RuleViolation> allow(GraphCommandExecutionContext context) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        public CommandResult<RuleViolation> execute(GraphCommandExecutionContext context) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
-
-        @Override
-        public CommandResult<RuleViolation> undo(GraphCommandExecutionContext context) {
-            return GraphCommandResultBuilder.SUCCESS;
-        }
+        //fails here
+        verify(tested).addCommand(any(Command.class));
     }
 }


### PR DESCRIPTION
**Warning**: This is not a PR to merge this is the PR to show some things.

Hi @romartin,

I looked at org.kie.workbench.common.stunner.core.command.impl.* there are some thoughts:

1. CommandManagerImpl and CommandRegistryListener tested well
2. CompositeCommandTest doesn't test CompositeCommandImpl but CompositeCommandStub see code changes. When I replaced stub by real implementations two of three tests are failed, the last one runs AbstractCompositeCommand, not CompositeCommandImpl.
3. So CompositeCommandImpl is not tested at all.
3. DelegateCommandManagerListener is not tested at all either.
4. AbstractCompositeCommand has 66% lines covered

Feel free to use this PR as a base for your changes.

