### PR TITLE
JBPM-5632: Search artifacts both by name and file extension

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/widget/artifact/ArtifactListWidgetPresenter.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/main/java/org/kie/workbench/common/screens/server/management/client/widget/artifact/ArtifactListWidgetPresenter.java
@@ -59,7 +59,7 @@ public class ArtifactListWidgetPresenter {
         artifactListPresenter.notifyOnRefresh( false );
         artifactListPresenter.setup( ColumnType.GAV );
         this.view.init( this );
-        artifactListPresenter.search( "" );
+        search( "" );
     }
 
     public View getView() {

--- a/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/widget/artifact/ArtifactListWidgetPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-client/src/test/java/org/kie/workbench/common/screens/server/management/client/widget/artifact/ArtifactListWidgetPresenterTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.screens.server.management.client.widget.artifact;
 
 import java.util.Arrays;
+import java.util.List;
 import javax.enterprise.event.Event;
 
 import org.guvnor.m2repo.client.widgets.ArtifactListPresenter;
@@ -33,6 +34,8 @@ import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ArtifactListWidgetPresenterTest {
+
+    private List<String> FORMATS = Arrays.asList( "*.jar" );
 
     @Mock
     ArtifactListWidgetPresenter.View view;
@@ -55,14 +58,14 @@ public class ArtifactListWidgetPresenterTest {
         assertEquals( artifactListPresenter.getView(), presenter.getArtifactListView() );
         verify( artifactListPresenter ).notifyOnRefresh( false );
         verify( artifactListPresenter ).setup( ColumnType.GAV );
-        verify( artifactListPresenter ).search( "" );
+        verify( artifactListPresenter ).search( "", FORMATS );
     }
 
     @Test
     public void testSearch() {
         presenter.search( "something" );
 
-        verify( artifactListPresenter ).search( "something", Arrays.asList( "*.jar" ) );
+        verify( artifactListPresenter ).search( "something", FORMATS );
     }
 
     @Test


### PR DESCRIPTION
There was inconsistency in searching of available artifacts. This PR inludes file extension to search criteria. Before this PR the file extension was replaced by null value what probably caused duplication of entries in list of available artifacts.