### PR TITLE
Synchronize Freemarker setup to avoid concurrency issues

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/AbstractAdapterGenerator.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-core/kie-wb-common-stunner-processors/src/main/java/org/kie/workbench/common/stunner/core/processors/AbstractAdapterGenerator.java
@@ -39,19 +39,21 @@ public abstract class AbstractAdapterGenerator {
     protected Configuration config;
 
     public AbstractAdapterGenerator() {
-        try {
-            this.config = new Configuration();
-            this.config.setClassForTemplateLoading(this.getClass(),
-                                                   "templates");
-            this.config.setObjectWrapper(new DefaultObjectWrapper());
-        } catch (NoClassDefFoundError var2) {
-            if (var2.getCause() == null) {
-                var2.initCause(INITIALIZER_EXCEPTION);
+        synchronized (AbstractAdapterGenerator.class) {
+            try {
+                this.config = new Configuration();
+                this.config.setClassForTemplateLoading(this.getClass(),
+                                                       "templates");
+                this.config.setObjectWrapper(new DefaultObjectWrapper());
+            } catch (NoClassDefFoundError var2) {
+                if (var2.getCause() == null) {
+                    var2.initCause(INITIALIZER_EXCEPTION);
+                }
+                throw var2;
+            } catch (ExceptionInInitializerError var3) {
+                INITIALIZER_EXCEPTION = var3;
+                throw var3;
             }
-            throw var2;
-        } catch (ExceptionInInitializerError var3) {
-            INITIALIZER_EXCEPTION = var3;
-            throw var3;
         }
     }
 


### PR DESCRIPTION
This should fix the the following error, sometimes seen in the build:
External error in org.kie.workbench.common.stunner.core.processors.MainProcessorjava.lang.ExceptionInInitializerError
  at freemarker.template.ObjectWrapper.<clinit>(ObjectWrapper.java:69)
  at freemarker.core.Configurable.<init>(Configurable.java:139)
  at freemarker.template.Configuration.<init>(Configuration.java:142)
  at freemarker.template.Configuration.<clinit>(Configuration.java:127)
  at org.uberfire.annotations.processors.AbstractGenerator.<init>(AbstractGenerator.java:44)
  at org.kie.workbench.common.stunner.core.processors.rule.ContainmentRuleGenerator.<init>(ContainmentRuleGenerator.java:43)
  at org.kie.workbench.common.stunner.core.processors.MainProcessor.<init>(MainProcessor.java:194)

The same change was done in UF few months back as well: https://github.com/uberfire/uberfire/blob/master/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/AbstractGenerator.java