### PR TITLE
PLANNER-736: Workbench: Prevent user from creating multiple @PlanningSolution data objects

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-api/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>errai-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-marshalling</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenterTestBase.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/DataModelerScreenPresenterTestBase.java
@@ -51,11 +51,16 @@ import org.kie.workbench.common.services.datamodeller.core.PropertyType;
 import org.kie.workbench.common.services.datamodeller.core.impl.PropertyTypeFactoryImpl;
 import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
 import org.kie.workbench.common.services.shared.project.KieProject;
+import org.kie.workbench.common.services.shared.validation.ValidationService;
+import org.kie.workbench.common.widgets.client.popups.validation.ValidationPopup;
 import org.kie.workbench.common.widgets.metadata.client.KieEditorWrapperView;
 import org.kie.workbench.common.widgets.metadata.client.widget.OverviewWidgetPresenter;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.mvp.LockRequiredEvent;
+import org.uberfire.ext.editor.commons.client.file.popups.CopyPopUpPresenter;
+import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
+import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
@@ -96,6 +101,12 @@ public abstract class DataModelerScreenPresenterTestBase {
     protected DataModelerService modelerService;
 
     @Mock
+    protected ValidationPopup validationPopup;
+
+    @Mock
+    protected ValidationService validationService;
+
+    @Mock
     protected ValidatorService validatorService;
 
     @Mock
@@ -117,6 +128,15 @@ public abstract class DataModelerScreenPresenterTestBase {
 
     @Mock
     protected PlaceRequest placeRequest;
+
+    @Mock
+    protected SavePopUpPresenter savePopUpPresenter;
+
+    @Mock
+    protected RenamePopUpPresenter renamePopUpPresenter;
+
+    @Mock
+    protected CopyPopUpPresenter copyPopUpPresenter;
 
     protected DataModelerScreenPresenter presenter;
 
@@ -184,6 +204,9 @@ public abstract class DataModelerScreenPresenterTestBase {
                 this.versionRecordManager = DataModelerScreenPresenterTestBase.this.versionRecordManager;
                 this.authorizationManager = DataModelerScreenPresenterTestBase.this.authorizationManager;
                 overviewWidget = mock( OverviewWidgetPresenter.class );
+                savePopUpPresenter = DataModelerScreenPresenterTestBase.this.savePopUpPresenter;
+                renamePopUpPresenter = DataModelerScreenPresenterTestBase.this.renamePopUpPresenter;
+                copyPopUpPresenter = DataModelerScreenPresenterTestBase.this.copyPopUpPresenter;
 
                 javaSourceEditor = DataModelerScreenPresenterTestBase.this.javaSourceEditor;
                 dataModelerEvent = DataModelerScreenPresenterTestBase.this.dataModelerEvent;
@@ -191,8 +214,9 @@ public abstract class DataModelerScreenPresenterTestBase {
                 publishBatchMessagesEvent = DataModelerScreenPresenterTestBase.this.publishBatchMessagesEvent;
                 lockRequired = DataModelerScreenPresenterTestBase.this.lockRequired;
                 dataModelerFocusEvent = DataModelerScreenPresenterTestBase.this.dataModelerFocusEvent;
-                modelerService = new CallerMock<DataModelerService>(
-                        DataModelerScreenPresenterTestBase.this.modelerService );
+                modelerService = new CallerMock<>( DataModelerScreenPresenterTestBase.this.modelerService );
+                validationPopup = DataModelerScreenPresenterTestBase.this.validationPopup;
+                validationService = new CallerMock<>( DataModelerScreenPresenterTestBase.this.validationService );
                 validatorService = DataModelerScreenPresenterTestBase.this.validatorService;
                 javaFileNameValidator = DataModelerScreenPresenterTestBase.this.javaFileNameValidator;
                 resourceType = DataModelerScreenPresenterTestBase.this.resourceType;

--- a/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/widgets/DataModelerEditorsTestHelper.java
+++ b/kie-wb-common-screens/kie-wb-common-data-modeller/kie-wb-common-data-modeller-client/src/test/java/org/kie/workbench/common/screens/datamodeller/client/widgets/DataModelerEditorsTestHelper.java
@@ -44,6 +44,7 @@ import org.kie.workbench.common.services.datamodeller.core.impl.DataObjectImpl;
 import org.kie.workbench.common.services.datamodeller.core.impl.PropertyTypeFactoryImpl;
 import org.kie.workbench.common.services.datamodeller.driver.impl.annotations.CommonAnnotations;
 import org.kie.workbench.common.services.datamodeller.util.DriverUtils;
+import org.kie.workbench.common.services.shared.project.KieProject;
 import org.uberfire.commons.data.Pair;
 
 public class DataModelerEditorsTestHelper {
@@ -122,6 +123,7 @@ public class DataModelerEditorsTestHelper {
 
         EditorModelContent content = new EditorModelContent();
         content.setDataModel( createTestModel() );
+        content.setCurrentProject( new KieProject() );
         context.setEditorModelContent( content );
 
         return context;

--- a/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/util/PopupsUtil.java
+++ b/kie-wb-common-screens/kie-wb-common-datasource-mgmt/kie-wb-common-datasource-mgmt-client/src/main/java/org/kie/workbench/common/screens/datasource/management/client/util/PopupsUtil.java
@@ -18,6 +18,7 @@ package org.kie.workbench.common.screens.datasource.management.client.util;
 
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
@@ -28,6 +29,9 @@ import org.uberfire.mvp.Command;
 
 @ApplicationScoped
 public class PopupsUtil {
+
+    @Inject
+    private ValidationPopup validationPopup;
 
     public PopupsUtil() {
     }
@@ -83,6 +87,6 @@ public class PopupsUtil {
     }
 
     public void showValidationMessages( final List<ValidationMessage> messages ) {
-        ValidationPopup.showMessages( messages );
+        validationPopup.showMessages( messages );
     }
 }

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/validation/CopyValidator.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/validation/CopyValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.shared.validation;
+
+import java.util.Collection;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+import org.uberfire.backend.vfs.Path;
+
+/**
+ * Checks whether copy action can be safely performed. Implement this class in order to define
+ * custom check criterion.
+ *
+ * The checks are collected by org.kie.workbench.common.services.shared.validation.ValidationService
+ */
+public interface CopyValidator<T> {
+
+    Collection<ValidationMessage> validate( final Path path,
+                                            final T content );
+
+    Collection<ValidationMessage> validate( final Path path );
+
+    boolean accept( final Path path );
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/validation/SaveValidator.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/validation/SaveValidator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.services.shared.validation;
+
+import java.util.Collection;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+import org.uberfire.backend.vfs.Path;
+
+/**
+ * Checks whether save action can be safely performed. Implement this class in order to define
+ * custom check criterion.
+ *
+ * The checks are collected by org.kie.workbench.common.services.shared.validation.ValidationService
+ */
+public interface SaveValidator<T> {
+
+    Collection<ValidationMessage> validate( Path path,
+                                            T content );
+
+    boolean accept( final Path path );
+}

--- a/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/validation/ValidationService.java
+++ b/kie-wb-common-services/kie-wb-common-services-api/src/main/java/org/kie/workbench/common/services/shared/validation/ValidationService.java
@@ -15,9 +15,11 @@
  */
 package org.kie.workbench.common.services.shared.validation;
 
+import java.util.Collection;
 import java.util.Map;
 
 import org.guvnor.common.services.project.model.POM;
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
 
@@ -71,5 +73,13 @@ public interface ValidationService {
      * @return true if valid
      */
     boolean validateGAVVersion( final String version );
+
+    <T> Collection<ValidationMessage> validateForSave( final Path path,
+                                                       final T content );
+
+    <T> Collection<ValidationMessage> validateForCopy( final Path path,
+                                                       final T content );
+
+    Collection<ValidationMessage> validateForCopy( final Path path );
 
 }

--- a/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/ValidationServiceImplTest.java
+++ b/kie-wb-common-services/kie-wb-common-services-backend/src/test/java/org/kie/workbench/common/services/backend/validation/ValidationServiceImplTest.java
@@ -16,11 +16,15 @@
 
 package org.kie.workbench.common.services.backend.validation;
 
+import javax.enterprise.inject.Instance;
+
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.validation.CopyValidator;
+import org.kie.workbench.common.services.shared.validation.SaveValidator;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -38,6 +42,10 @@ public class ValidationServiceImplTest {
     private ProjectNameValidator projectValidator;
     @Mock
     private JavaFileNameValidator javaValidator;
+    @Mock
+    private Instance<SaveValidator> saveValidatorInstance;
+    @Mock
+    private Instance<CopyValidator> copyValidatorInstance;
 
     @InjectMocks
     private ValidationServiceImpl validationService;

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationMessageTranslator.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationMessageTranslator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.validation;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+
+public interface ValidationMessageTranslator {
+
+    boolean accept( final ValidationMessage checkMessage );
+
+    ValidationMessage translate( final ValidationMessage checkMessage );
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationMessageTranslatorUtils.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationMessageTranslatorUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+
+@ApplicationScoped
+public class ValidationMessageTranslatorUtils {
+
+    private List<ValidationMessageTranslator> validationMessageTranslators = new ArrayList<>();
+
+    public ValidationMessageTranslatorUtils() {
+    }
+
+    @Inject
+    public ValidationMessageTranslatorUtils( Instance<ValidationMessageTranslator> checkTranslators ) {
+        checkTranslators.forEach( this.validationMessageTranslators::add );
+    }
+
+    public List<ValidationMessage> translate( List<ValidationMessage> messages ) {
+        return messages.stream().map( m -> lookUpTranslation( m ) ).collect( Collectors.toList() );
+    }
+
+    private ValidationMessage lookUpTranslation( ValidationMessage messageToTranslate ) {
+        return validationMessageTranslators.stream()
+                .filter( t -> t.accept( messageToTranslate ) )
+                .map( t -> t.translate( messageToTranslate ) )
+                .findFirst()
+                .orElse( messageToTranslate );
+    }
+
+    // Test purposes
+    void setValidationMessageTranslators( List<ValidationMessageTranslator> messageTranslators ) {
+        this.validationMessageTranslators = messageTranslators;
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopup.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopup.java
@@ -1,84 +1,129 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.kie.workbench.common.widgets.client.popups.validation;
 
 import java.util.List;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
-import com.google.gwt.user.client.Command;
-import com.google.gwt.view.client.ListDataProvider;
-import com.google.gwt.view.client.Range;
-import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
-import org.guvnor.messageconsole.client.console.widget.MessageTableWidget;
-import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
-import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
-import org.uberfire.ext.widgets.common.client.common.popups.footers.ModalFooterOKButton;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.kie.workbench.common.widgets.client.resources.i18n.KieWorkbenchWidgetsConstants;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.mvp.Command;
 
-/**
- * A popup that lists BuildMessages
- */
-public class ValidationPopup extends BaseModal {
+@Dependent
+public class ValidationPopup implements ValidationPopupView.Presenter {
 
-    private static ValidationPopup instance = new ValidationPopup();
+    private ValidationPopupView view;
 
-    protected final MessageTableWidget<ValidationMessage> dataGrid = new MessageTableWidget<ValidationMessage>( MessageTableWidget.Mode.PAGED ) {{
-        setDataProvider( new ListDataProvider<ValidationMessage>() );
-    }};
+    private ValidationMessageTranslatorUtils validationMessageTranslatorUtils;
 
-    private ValidationPopup() {
-        setTitle( CommonConstants.INSTANCE.ValidationErrors() );
-        setHideOtherModals( false );
+    private TranslationService translationService;
 
-        setBody( dataGrid );
+    private Command yesCommand;
 
-        add( new ModalFooterOKButton( new Command() {
-            @Override
-            public void execute() {
-                hide();
-            }
-        } ) );
+    private Command cancelCommand;
 
-        dataGrid.setToolBarVisible( false );
-
-        dataGrid.addLevelColumn( 10, new MessageTableWidget.ColumnExtractor<Level>() {
-            @Override
-            public Level getValue( final Object row ) {
-                final Level level = ( (ValidationMessage) row ).getLevel();
-                return level != null ? level : Level.ERROR;
-            }
-        } );
-
-        dataGrid.addTextColumn( 90, new MessageTableWidget.ColumnExtractor<String>() {
-            @Override
-            public String getValue( final Object row ) {
-                return ( (ValidationMessage) row ).getText();
-            }
-        } );
+    @Inject
+    public ValidationPopup( final ValidationPopupView view,
+                            final ValidationMessageTranslatorUtils validationMessageTranslatorUtils,
+                            final TranslationService translationService ) {
+        this.view = view;
+        this.validationMessageTranslatorUtils = validationMessageTranslatorUtils;
+        this.translationService = translationService;
     }
 
-    private void setMessages( final List<ValidationMessage> messages ) {
-        final ListDataProvider<ValidationMessage> listDataProvider = (ListDataProvider<ValidationMessage>) this.dataGrid.getDataProvider();
-        listDataProvider.getList().clear();
-        listDataProvider.getList().addAll( messages );
-        this.dataGrid.setVisibleRangeAndClearData( new Range( 0, 5 ), true );
+    @PostConstruct
+    public void init() {
+        view.init( this );
     }
 
-    public static void showMessages( final List<ValidationMessage> messages ) {
-        instance.setMessages( messages );
-        instance.show();
+    public void showMessages( final List<ValidationMessage> messages ) {
+        clear();
+        view.setCancelButtonText( translationService.getTranslation( KieWorkbenchWidgetsConstants.ValidationPopup_Cancel ) );
+        view.showCancelButton( true );
+
+        initAndShowModal( () -> {},
+                          () -> {},
+                          messages );
     }
 
+    public void showCopyValidationMessages( final Command yesCommand,
+                                            final Command cancelCommand,
+                                            final List<ValidationMessage> validationMessages ) {
+        clear();
+        view.setYesButtonText( translationService.getTranslation( KieWorkbenchWidgetsConstants.ValidationPopup_YesCopyAnyway ) );
+        view.showYesButton( true );
+
+        view.setCancelButtonText( translationService.getTranslation( KieWorkbenchWidgetsConstants.ValidationPopup_Cancel ) );
+        view.showCancelButton( true );
+
+        initAndShowModal( yesCommand,
+                          cancelCommand,
+                          validationMessages );
+    }
+
+    public void showSaveValidationMessages( final Command yesCommand,
+                                            final Command cancelCommand,
+                                            final List<ValidationMessage> validationMessages ) {
+        clear();
+        view.setYesButtonText( translationService.getTranslation( KieWorkbenchWidgetsConstants.ValidationPopup_YesSaveAnyway ) );
+        view.showYesButton( true );
+
+        view.setCancelButtonText( translationService.getTranslation( KieWorkbenchWidgetsConstants.ValidationPopup_Cancel ) );
+        view.showCancelButton( true );
+
+        initAndShowModal( yesCommand,
+                          cancelCommand,
+                          validationMessages );
+    }
+
+    private void initAndShowModal( final Command yesCommand,
+                                   final Command cancelCommand,
+                                   final List<ValidationMessage> validationMessages ) {
+        this.yesCommand = PortablePreconditions.checkNotNull( "yesCommand",
+                                                              yesCommand );
+        this.cancelCommand = PortablePreconditions.checkNotNull( "cancelCommand",
+                                                                 cancelCommand );
+
+        view.setValidationMessages( validationMessageTranslatorUtils.translate( validationMessages ) );
+        view.show();
+    }
+
+    private void clear() {
+        view.showYesButton( false );
+        view.showCancelButton( false );
+    }
+
+    @Override
+    public void onYesButtonClicked() {
+        if ( yesCommand != null ) {
+            yesCommand.execute();
+        }
+        view.hide();
+    }
+
+    @Override
+    public void onCancelButtonClicked() {
+        if ( cancelCommand != null ) {
+            cancelCommand.execute();
+        }
+        view.hide();
+    }
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupView.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.validation;
+
+import java.util.List;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+import org.uberfire.client.mvp.UberElement;
+
+public interface ValidationPopupView extends UberElement<ValidationPopupView.Presenter> {
+
+    interface Presenter {
+
+        void onYesButtonClicked();
+
+        void onCancelButtonClicked();
+    }
+
+    void setYesButtonText( final String text );
+
+    void setCancelButtonText( final String text );
+
+    void showYesButton( final boolean show );
+
+    void showCancelButton( final boolean show );
+
+    void setValidationMessages( final List<ValidationMessage> messages );
+
+    void show();
+
+    void hide();
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupViewImpl.html
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupViewImpl.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div id="view">
+    <div class="container-fluid">
+        <table id="validationTable"></table>
+        <div class="modal-footer">
+            <button id="cancelButton"></button>
+            <button id="yesButton" class="btn btn-primary"></button>
+        </div>
+    </div>
+</div>

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupViewImpl.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupViewImpl.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.validation;
+
+import java.util.List;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwt.view.client.Range;
+import org.guvnor.common.services.shared.message.Level;
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+import org.guvnor.messageconsole.client.console.widget.MessageTableWidget;
+import org.jboss.errai.common.client.dom.Button;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.kie.workbench.common.widgets.client.resources.i18n.KieWorkbenchWidgetsConstants;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+
+@Dependent
+@Templated
+public class ValidationPopupViewImpl implements ValidationPopupView {
+
+    @DataField("view")
+    Div view;
+
+    @DataField("validationTable")
+    MessageTableWidget<ValidationMessage> validationTable;
+
+    @DataField("yesButton")
+    Button yesButton;
+
+    @DataField("cancelButton")
+    Button cancelButton;
+
+    private Presenter presenter;
+
+    private BaseModal modal;
+
+    private ListDataProvider<ValidationMessage> validationTableDataProvider;
+
+    private TranslationService translationService;
+
+    @Inject
+    public ValidationPopupViewImpl( final Div view,
+                                    final Button yesButton,
+                                    final Button cancelButton,
+                                    final TranslationService translationService ) {
+        this.view = view;
+        this.yesButton = yesButton;
+        this.cancelButton = cancelButton;
+        this.translationService = translationService;
+
+        this.validationTable = new MessageTableWidget<>( MessageTableWidget.Mode.PAGED );
+        validationTable.setDataProvider( new ListDataProvider<>() );
+
+        validationTable.addLevelColumn( 10,
+                                        row -> {
+                                            final Level level = ( (ValidationMessage) row ).getLevel();
+                                            return level != null ? level : Level.ERROR;
+                                        } );
+
+        validationTable.addTextColumn( 90,
+                                       row -> ( (ValidationMessage) row ).getText() );
+
+        validationTableDataProvider = new ListDataProvider<>();
+        validationTableDataProvider.addDataDisplay( validationTable );
+    }
+
+
+    @Override
+    public void init( final Presenter presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return view;
+    }
+
+    @Override
+    public void setYesButtonText( final String text ) {
+        yesButton.setTextContent( text );
+    }
+
+    @Override
+    public void setCancelButtonText( final String text ) {
+        cancelButton.setTextContent( text );
+    }
+
+    @Override
+    public void showYesButton( final boolean show ) {
+        yesButton.getStyle().setProperty( "display", show ? "inline" : "none" );
+    }
+
+    @Override
+    public void showCancelButton( final boolean show ) {
+        cancelButton.getStyle().setProperty( "display", show ? "inline" : "none" );
+    }
+
+    @Override
+    public void setValidationMessages( List<ValidationMessage> messages ) {
+        ListDataProvider<ValidationMessage> listDataProvider = (ListDataProvider<ValidationMessage>) this.validationTable.getDataProvider();
+        listDataProvider.getList().clear();
+        listDataProvider.getList().addAll( messages );
+        validationTable.setVisibleRangeAndClearData( new Range( 0, 5 ), true );
+    }
+
+    @Override
+    public void show() {
+        modal = new BaseModal();
+        modal.setTitle( translationService.getTranslation( KieWorkbenchWidgetsConstants.ValidationPopupViewImpl_ValidationErrors ) );
+        modal.setBody( ElementWrapperWidget.getWidget( view ) );
+        modal.show();
+    }
+
+    @Override
+    public void hide() {
+        if ( modal != null ) {
+            modal.hide();
+        }
+    }
+
+    @EventHandler("yesButton")
+    public void yesButtonClicked( final ClickEvent clickEvent ) {
+        presenter.onYesButtonClicked();
+    }
+
+    @EventHandler("cancelButton")
+    public void cancelButtonClicked( final ClickEvent clickEvent ) {
+        presenter.onCancelButtonClicked();
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/resources/i18n/KieWorkbenchWidgetsConstants.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/java/org/kie/workbench/common/widgets/client/resources/i18n/KieWorkbenchWidgetsConstants.java
@@ -40,4 +40,16 @@ public interface KieWorkbenchWidgetsConstants {
 
     @TranslationKey( defaultValue = "Path in which to create new resource is missing. Please enter.")
     String NewResourceViewMissingPath = "NewResourceViewImpl.MissingPath";
+
+    @TranslationKey( defaultValue = "" )
+    String ValidationPopup_YesSaveAnyway = "ValidationPopup.YesSaveAnyway";
+
+    @TranslationKey( defaultValue = "" )
+    String ValidationPopup_YesCopyAnyway = "ValidationPopup.YesCopyAnyway";
+
+    @TranslationKey( defaultValue = "" )
+    String ValidationPopup_Cancel = "ValidationPopup.Cancel";
+
+    @TranslationKey( defaultValue = "" )
+    String ValidationPopupViewImpl_ValidationErrors = "ValidationPopupViewImpl.ValidationErrors";
 }

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/resources/org/kie/workbench/common/widgets/client/resources/i18n/KieWorkbenchWidgetsConstants.properties
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/resources/org/kie/workbench/common/widgets/client/resources/i18n/KieWorkbenchWidgetsConstants.properties
@@ -5,3 +5,8 @@ NewResourceViewImpl.resourceName=Resource Name
 NewResourceViewImpl.packageName=Package
 NewResourceViewImpl.resourceNamePlaceholder=Name...
 NewResourceViewImpl.MissingPath=Path in which to create new resource is missing. Please enter.
+
+ValidationPopup.YesSaveAnyway=Yes, save anyway
+ValidationPopup.YesCopyAnyway=Yes, copy anyway
+ValidationPopup.Cancel=Cancel
+ValidationPopupViewImpl.ValidationErrors=Validation errors

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/main/resources/org/kie/workbench/common/widgets/client/resources/i18n/ValidationConstants.properties
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/main/resources/org/kie/workbench/common/widgets/client/resources/i18n/ValidationConstants.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ValidationPopup.ValidationErrors=Validation errors
+ValidationPopup.YesSaveAnyway=Yes, save anyway
+ValidationPopup.YesCopyAnyway=Yes, copy anyway
+ValidationPopup.Cancel=Cancel

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationMessageTranslatorUtilsTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationMessageTranslatorUtilsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.validation;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.enterprise.inject.Instance;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValidationMessageTranslatorUtilsTest {
+
+    @Mock
+    private Instance<ValidationMessageTranslator> messageTranslatorInstance;
+
+    private ValidationMessageTranslatorUtils translatorUtils;
+
+    @Before
+    public void setUp() {
+        translatorUtils = new ValidationMessageTranslatorUtils( messageTranslatorInstance );
+    }
+
+    @Test
+    public void translateMessageExists() {
+        translatorUtils.setValidationMessageTranslators( Arrays.asList( new UniversalTestTranslator() ) );
+
+        TestMessage messageToTranslate = new TestMessage();
+
+        List<ValidationMessage> result = translatorUtils.translate( Arrays.asList( messageToTranslate ) );
+        assertEquals( 1, result.size() );
+        assertEquals( "Translated message", result.get( 0 ).getText() );
+    }
+
+    public void translateMessageNonAcceptingTranslator() {
+        translatorUtils.setValidationMessageTranslators( Arrays.asList( new FalsumTestTranslator() ) );
+
+        TestMessage messageToTranslate = new TestMessage();
+
+        List<ValidationMessage> result = translatorUtils.translate( Arrays.asList( messageToTranslate ) );
+        assertEquals( 1, result.size() );
+        assertNull( result.get( 0 ).getText() );
+    }
+
+    private class UniversalTestTranslator implements ValidationMessageTranslator {
+
+        @Override
+        public boolean accept( ValidationMessage message ) {
+            return true;
+        }
+
+        @Override
+        public ValidationMessage translate( ValidationMessage checkMessage ) {
+            checkMessage.setText( "Translated message" );
+            return checkMessage;
+        }
+    }
+
+    private class FalsumTestTranslator implements ValidationMessageTranslator {
+
+        @Override
+        public boolean accept( ValidationMessage message ) {
+            return false;
+        }
+
+        @Override
+        public ValidationMessage translate( ValidationMessage checkMessage ) {
+            return null;
+        }
+    }
+
+    private class TestMessage extends ValidationMessage {
+    }
+}

--- a/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupTest.java
+++ b/kie-wb-common-widgets/kie-wb-common-ui/src/test/java/org/kie/workbench/common/widgets/client/popups/validation/ValidationPopupTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.widgets.client.popups.validation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValidationPopupTest {
+
+    @Mock
+    private ValidationPopupView view;
+
+    @Mock
+    private ValidationMessageTranslatorUtils validationMessageTranslatorUtils;
+
+    @Mock
+    private TranslationService translationService;
+
+    private ValidationPopup validationPopup;
+
+    @Before
+    public void setUp() {
+        validationPopup = new ValidationPopup( view,
+                                               validationMessageTranslatorUtils,
+                                               translationService );
+
+        view.init( validationPopup );
+    }
+
+    @Test
+    public void showMessages() {
+        ValidationMessage validationMessage = new ValidationMessage();
+
+        validationPopup.showMessages( Arrays.asList( validationMessage ) );
+
+        verify( view ).showYesButton( false );
+        verify( view ).showCancelButton( true );
+
+        verify( view ).setValidationMessages( anyListOf( ValidationMessage.class ) );
+        verify( view ).show();
+    }
+
+    @Test
+    public void showCopyValidationMessages() {
+        List<ValidationMessage> validationMessages = Arrays.asList( new ValidationMessage() );
+
+        validationPopup.showCopyValidationMessages( () -> {},
+                                                    () -> {},
+                                                    validationMessages );
+
+        verify( view ).showYesButton( true );
+        verify( view ).showCancelButton( true );
+
+        List<ValidationMessage> translatedMessages = Collections.emptyList();
+        when( validationMessageTranslatorUtils.translate( validationMessages ) ).thenReturn( translatedMessages );
+
+        verify( view ).setValidationMessages( translatedMessages );
+        verify( view ).show();
+    }
+
+    @Test
+    public void showSaveValidationMessages() {
+        List<ValidationMessage> validationMessages = Arrays.asList( new ValidationMessage() );
+
+        validationPopup.showSaveValidationMessages( () -> {},
+                                                    () -> {},
+                                                    validationMessages );
+
+        verify( view ).showYesButton( true );
+        verify( view ).showCancelButton( true );
+
+        List<ValidationMessage> translatedMessages = Collections.emptyList();
+        when( validationMessageTranslatorUtils.translate( validationMessages ) ).thenReturn( translatedMessages );
+
+        verify( view ).setValidationMessages( translatedMessages );
+        verify( view ).show();
+    }
+}


### PR DESCRIPTION
Introduce pre-save & pre-copy checks to make sure the user doesn't create multiple Planning Solutions within a project. The checks reside on the server side and can be easily defined by implementing PreSaveOperationCheck & PreCopyOperationCheck classes.

DataModelerOperationCheckService provides methods to verify all conditions (checks) in a single place.

As the checks are performed on the server side, there was a need to provide mapping between the server-side messages & client-side messages (where the latter are i18ned). This is managed by OperationCheckTranslator class.

Part of:
https://github.com/droolsjbpm/guvnor/pull/416
https://github.com/droolsjbpm/jbpm-wb/pull/630
https://github.com/droolsjbpm/kie-wb-common/pull/681
https://github.com/droolsjbpm/optaplanner-wb/pull/134

@manstis / @wmedvede Can you please have a look at the PR? Thanks.