### PR TITLE
GUVNOR-2856: [Guided Decision Table] Remove import throws exception

### DIFF
--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetView.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/main/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetView.java
@@ -29,21 +29,21 @@ public interface ImportsWidgetView
 
     interface Presenter {
 
-        void setContent( final AsyncPackageDataModelOracle dmo,
-                         final Imports resourceImports,
-                         final boolean isReadOnly );
+        void setContent(final AsyncPackageDataModelOracle dmo,
+                        final Imports resourceImports,
+                        final boolean isReadOnly);
 
-        void onAddImport( final Import importType );
+        boolean isInternalImport(final Import importType);
 
-        void onRemoveImport( final Import importType );
+        void onAddImport(final Import importType);
+
+        void onRemoveImport(final Import importType);
 
         Widget asWidget();
-
     }
 
-    void setContent( final List<Import> internalFactTypes,
-                     final List<Import> externalFactTypes,
-                     final List<Import> importTypes,
-                     final boolean isReadOnly );
-
+    void setContent(final List<Import> internalFactTypes,
+                    final List<Import> externalFactTypes,
+                    final List<Import> importTypes,
+                    final boolean isReadOnly);
 }

--- a/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetPresenterTest.java
+++ b/kie-wb-common-widgets/kie-wb-config-resource-widget/src/test/java/org/kie/workbench/common/widgets/configresource/client/widget/bound/ImportsWidgetPresenterTest.java
@@ -66,122 +66,169 @@ public class ImportsWidgetPresenterTest {
 
     @Before
     public void setup() {
-        when( dmo.getInternalFactTypes() ).thenReturn( new String[]{ "Internal1", "Internal2", "Internal3" } );
-        when( dmo.getExternalFactTypes() ).thenReturn( new String[]{ "org.pkg1.External1", "org.pkg1.External2", "org.pkg1.External3" } );
+        when(dmo.getInternalFactTypes()).thenReturn(new String[]{"Internal1", "Internal2", "Internal3"});
+        when(dmo.getExternalFactTypes()).thenReturn(new String[]{"org.pkg1.External1", "org.pkg1.External2", "org.pkg1.External3"});
     }
 
     @Test
     public void testSetup() {
-        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter( view,
-                                                                             importAddedEvent,
-                                                                             importRemovedEvent );
-        verify( view,
-                times( 1 ) ).init( presenter );
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
+        verify(view,
+               times(1)).init(presenter);
     }
 
     @Test
     public void testSetContent() {
-        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter( view,
-                                                                             importAddedEvent,
-                                                                             importRemovedEvent );
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
         final Imports imports = new Imports();
-        imports.addImport( new Import( "Internal1" ) );
+        imports.addImport(new Import("Internal1"));
 
-        presenter.setContent( dmo,
-                              imports,
-                              false );
+        presenter.setContent(dmo,
+                             imports,
+                             false);
 
-        verify( view,
-                times( 1 ) ).setContent( internalFactTypesCaptor.capture(),
-                                         externalFactTypesCaptor.capture(),
-                                         importsFactTypesCaptor.capture(),
-                                         eq( false ) );
+        verify(view,
+               times(1)).setContent(internalFactTypesCaptor.capture(),
+                                    externalFactTypesCaptor.capture(),
+                                    importsFactTypesCaptor.capture(),
+                                    eq(false));
 
-        assertEquals( 3,
-                      internalFactTypesCaptor.getValue().size() );
-        assertContains( "Internal1",
-                        internalFactTypesCaptor.getValue() );
-        assertContains( "Internal2",
-                        internalFactTypesCaptor.getValue() );
-        assertContains( "Internal3",
-                        internalFactTypesCaptor.getValue() );
+        assertEquals(3,
+                     internalFactTypesCaptor.getValue().size());
+        assertContains("Internal1",
+                       internalFactTypesCaptor.getValue());
+        assertContains("Internal2",
+                       internalFactTypesCaptor.getValue());
+        assertContains("Internal3",
+                       internalFactTypesCaptor.getValue());
 
-        assertEquals( 3,
-                      externalFactTypesCaptor.getValue().size() );
-        assertContains( "org.pkg1.External1",
-                        externalFactTypesCaptor.getValue() );
-        assertContains( "org.pkg1.External2",
-                        externalFactTypesCaptor.getValue() );
-        assertContains( "org.pkg1.External3",
-                        externalFactTypesCaptor.getValue() );
+        assertEquals(3,
+                     externalFactTypesCaptor.getValue().size());
+        assertContains("org.pkg1.External1",
+                       externalFactTypesCaptor.getValue());
+        assertContains("org.pkg1.External2",
+                       externalFactTypesCaptor.getValue());
+        assertContains("org.pkg1.External3",
+                       externalFactTypesCaptor.getValue());
 
-        assertEquals( 0,
-                      importsFactTypesCaptor.getValue().size() );
+        assertEquals(0,
+                     importsFactTypesCaptor.getValue().size());
 
-        assertEquals( 1,
-                      imports.getImports().size() );
-        assertContains( "Internal1",
-                        imports.getImports() );
+        assertEquals(1,
+                     imports.getImports().size());
+        assertContains("Internal1",
+                       imports.getImports());
+    }
+
+    @Test
+    public void isInternalImportWithoutSetup() {
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
+        assertFalse(presenter.isInternalImport(mock(Import.class)));
+    }
+
+    @Test
+    public void isInternalImportWithoutSetupNullImportType() {
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
+        assertFalse(presenter.isInternalImport(null));
+    }
+
+    @Test
+    public void isInternalImportInternalImportType() {
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
+        final Imports imports = new Imports();
+        final Import importType = new Import("Internal1");
+        imports.addImport(importType);
+
+        presenter.setContent(dmo,
+                             imports,
+                             false);
+
+        assertTrue(presenter.isInternalImport(importType));
+    }
+
+    @Test
+    public void isInternalImportExternalImportType() {
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
+        final Imports imports = new Imports();
+        final Import importType = new Import("External1");
+        imports.addImport(importType);
+
+        presenter.setContent(dmo,
+                             imports,
+                             false);
+
+        assertFalse(presenter.isInternalImport(mock(Import.class)));
     }
 
     @Test
     public void testOnImportAdded() {
-        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter( view,
-                                                                             importAddedEvent,
-                                                                             importRemovedEvent );
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
         final Imports imports = new Imports();
-        imports.addImport( new Import( "Internal1" ) );
+        imports.addImport(new Import("Internal1"));
 
-        presenter.setContent( dmo,
-                              imports,
-                              false );
+        presenter.setContent(dmo,
+                             imports,
+                             false);
 
-        presenter.onAddImport( new Import( "NewImport1" ) );
+        presenter.onAddImport(new Import("NewImport1"));
 
-        assertEquals( 2,
-                      imports.getImports().size() );
-        assertContains( "Internal1",
-                        imports.getImports() );
-        assertContains( "NewImport1",
-                        imports.getImports() );
+        assertEquals(2,
+                     imports.getImports().size());
+        assertContains("Internal1",
+                       imports.getImports());
+        assertContains("NewImport1",
+                       imports.getImports());
 
-        verify( importAddedEvent,
-                times( 1 ) ).fire( importAddedEventCaptor.capture() );
-        assertEquals( "NewImport1",
-                      importAddedEventCaptor.getValue().getImport().getType() );
+        verify(importAddedEvent,
+               times(1)).fire(importAddedEventCaptor.capture());
+        assertEquals("NewImport1",
+                     importAddedEventCaptor.getValue().getImport().getType());
     }
 
     @Test
     public void testOnImportRemoved() {
-        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter( view,
-                                                                             importAddedEvent,
-                                                                             importRemovedEvent );
+        final ImportsWidgetPresenter presenter = new ImportsWidgetPresenter(view,
+                                                                            importAddedEvent,
+                                                                            importRemovedEvent);
         final Imports imports = new Imports();
-        imports.addImport( new Import( "Internal1" ) );
+        imports.addImport(new Import("Internal1"));
 
-        presenter.setContent( dmo,
-                              imports,
-                              false );
+        presenter.setContent(dmo,
+                             imports,
+                             false);
 
-        presenter.onRemoveImport( new Import( "Internal1" ) );
+        presenter.onRemoveImport(new Import("Internal1"));
 
-        assertEquals( 0,
-                      imports.getImports().size() );
+        assertEquals(0,
+                     imports.getImports().size());
 
-        verify( importRemovedEvent,
-                times( 1 ) ).fire( importRemovedEventCaptor.capture() );
-        assertEquals( "Internal1",
-                      importRemovedEventCaptor.getValue().getImport().getType() );
+        verify(importRemovedEvent,
+               times(1)).fire(importRemovedEventCaptor.capture());
+        assertEquals("Internal1",
+                     importRemovedEventCaptor.getValue().getImport().getType());
     }
 
-    private static void assertContains( final String factType,
-                                        final List<Import> factTypes ) {
-        for ( Import i : factTypes ) {
-            if ( i.getType().equals( factType ) ) {
+    private static void assertContains(final String factType,
+                                       final List<Import> factTypes) {
+        for (Import i : factTypes) {
+            if (i.getType().equals(factType)) {
                 return;
             }
         }
-        fail( "Expected Fact Type '" + factType + "' was not found." );
+        fail("Expected Fact Type '" + factType + "' was not found.");
     }
-
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2856

GWT's ```onBrowserEvent``` was throwing a RTE when the ```ButtonCell``` had no rendered content.

It is a general problem for the "Data Object imports" tab and not specific to Guided Decision Tables.

See https://github.com/droolsjbpm/kie-wb-common/pull/689/files?w=1 with whitespace diffs removed.