### PR TITLE
Remove transitive  dependency to Stunner.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/pom.xml
@@ -193,10 +193,6 @@
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-library-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.kie.workbench.stunner</groupId>
-      <artifactId>kie-wb-common-stunner-project-client</artifactId>
-    </dependency>
 
     <!-- GWT and GWT Extensions -->
     <dependency>

--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocks.java
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/java/org/kie/workbench/common/workbench/client/docks/AuthoringWorkbenchDocks.java
@@ -24,9 +24,6 @@ import org.kie.workbench.common.screens.datamodeller.client.DataModelerContext;
 import org.kie.workbench.common.screens.datamodeller.client.context.DataModelerWorkbenchContext;
 import org.kie.workbench.common.screens.datamodeller.client.context.DataModelerWorkbenchContextChangeEvent;
 import org.kie.workbench.common.screens.datamodeller.client.context.DataModelerWorkbenchFocusEvent;
-import org.kie.workbench.common.stunner.project.client.screens.ProjectDiagramExplorerScreen;
-import org.kie.workbench.common.stunner.project.client.screens.ProjectDiagramPropertiesScreen;
-import org.kie.workbench.common.stunner.project.client.screens.ProjectDiagramWorkbenchDocks;
 import org.kie.workbench.common.workbench.client.authz.WorkbenchFeatures;
 import org.kie.workbench.common.workbench.client.resources.i18n.DefaultWorkbenchConstants;
 import org.kie.workbench.common.workbench.client.resources.images.WorkbenchImageResources;
@@ -109,8 +106,8 @@ public class AuthoringWorkbenchDocks {
                 new UberfireDock( UberfireDockPosition.EAST, "RANDOM", new DefaultPlaceRequest( "DroolsDomainScreen" ), authoringPerspectiveIdentifier ).withSize( 450 ).withLabel( constants.DocksDroolsJBPMTitle() ),
                 new UberfireDock( UberfireDockPosition.EAST, "BRIEFCASE", new DefaultPlaceRequest( "JPADomainScreen" ), authoringPerspectiveIdentifier ).withSize( 450 ).withLabel( constants.DocksPersistenceTitle() ),
                 new UberfireDock( UberfireDockPosition.EAST, "COG", new DefaultPlaceRequest( "AdvancedDomainScreen" ), authoringPerspectiveIdentifier ).withSize( 450 ).withLabel( constants.DocksAdvancedTitle() ),
-                new UberfireDock( UberfireDockPosition.EAST, "PENCIL_SQUARE_O", new DefaultPlaceRequest(ProjectDiagramPropertiesScreen.SCREEN_ID), authoringPerspectiveIdentifier).withSize(450).withLabel(constants.DocksStunnerPropertiesTitle() ),
-                new UberfireDock( UberfireDockPosition.EAST, "EYE", new DefaultPlaceRequest(ProjectDiagramExplorerScreen.SCREEN_ID), authoringPerspectiveIdentifier).withSize(450).withLabel(constants.DocksStunnerExplorerTitle() )
+                new UberfireDock( UberfireDockPosition.EAST, "PENCIL_SQUARE_O", new DefaultPlaceRequest("ProjectDiagramPropertiesScreen"), authoringPerspectiveIdentifier).withSize(450).withLabel(constants.DocksStunnerPropertiesTitle() ),
+                new UberfireDock( UberfireDockPosition.EAST, "EYE", new DefaultPlaceRequest("ProjectDiagramExplorerScreen"), authoringPerspectiveIdentifier).withSize(450).withLabel(constants.DocksStunnerExplorerTitle() )
                          );
         uberfireDocks.disable( UberfireDockPosition.EAST, authoringPerspectiveIdentifier );
         dataModelerDocksEnabled = false;


### PR DESCRIPTION
Hey @manstis @pefernan @mbiarnes 
This commit fixes the wrong dependency from the workbench client module to stunner.
Thanks!