### PR TITLE
Remove transitive gwt module dependency to Stunner.

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/KieDefaultWorkbenchClient.gwt.xml
+++ b/kie-wb-common-screens/kie-wb-common-workbench/kie-wb-common-workbench-client/src/main/resources/org/kie/workbench/common/workbench/KieDefaultWorkbenchClient.gwt.xml
@@ -19,7 +19,6 @@
   <inherits name="org.kie.workbench.common.widgets.KieWorkbenchWidgetsCommon"/>
   <inherits name="org.kie.workbench.common.screens.library.LibraryClient"/>
   <inherits name='org.gwtbootstrap3.extras.typeahead.Typeahead'/>
-  <inherits name="org.kie.workbench.common.stunner.project.StunnerProjectClient"/>
 
   <source path="client"/>
   <source path="shared"/>


### PR DESCRIPTION
Hey @mbiarnes @manstis @pefernan @Rikkola ,

Sorry guys, I forgot to remove the gwt module dependency as well in [this already merged PR,](https://github.com/droolsjbpm/kie-wb-common/pull/708) so here is the fix for it. 

PS: It has been impossible for me, during this weekend, to do a full build for master, I'm facing with some compile issues and all seems up to date, so still not sure if it's just my local or something is bad on the repos... Anyway I say this because I was NOT  been able to test this commit - I expect making the repositories compile again, and for the jbpm-wb module  (which still does not depend on Stunner), the docks will appear on the showcase but probably will fail once trying to open it at runtime (as the hardcoded screen ids used for docks should not be present). Tomorrow will try again and see if there is a better fix for this, but meanwhile, I think this should be merged as the build for jbpm-wb was broken.
Thanks in advance!
Roger